### PR TITLE
Handle professional signup redirect

### DIFF
--- a/create-profile.html
+++ b/create-profile.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create Profile – TradeStone</title>
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h1 class="text-2xl font-bold mb-4 text-center">Create Your Professional Profile</h1>
+    <p class="mb-6 text-center">Profile setup coming soon.</p>
+    <div class="text-center">
+      <a href="login.html" class="text-orange-500 font-medium">Skip for now</a>
+    </div>
+  </main>
+
+  <!-- Home button -->
+  <div class="text-center mt-6">
+    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
+      <svg xmlns="http://www.w3.org/2000/svg"
+           class="h-8 w-8"
+           fill="none"
+           viewBox="0 0 24 24"
+           stroke="currentColor"
+           stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M9 22V12h6v10"/>
+      </svg>
+    </a>
+  </div>
+
+</body>
+</html>

--- a/signup.html
+++ b/signup.html
@@ -89,7 +89,11 @@
       try {
         const { user } = await createUserWithEmailAndPassword(auth, email, password);
         await setDoc(doc(db, 'users', user.uid), { accountType });
-        window.location.href = 'login.html';
+        if (accountType === 'professional') {
+          window.location.href = 'create-profile.html';
+        } else {
+          window.location.href = 'login.html';
+        }
       } catch(err) {
         alert(err.message);
       }


### PR DESCRIPTION
## Summary
- add create-profile page placeholder
- redirect professional accounts from signup to create-profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f17cb53c832baf27ade6fb09a099