### PR TITLE
Fix stray '<' on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- remove extra bracket from `index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846f76cd9ec832b8d8b259d0252cf1f