### PR TITLE
Centralize Firebase configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 
 ## Setup
 
-1. Ensure you have a Firebase project and replace the configuration found in the HTML files with your own credentials.
+1. Ensure you have a Firebase project and edit `firebaseConfig.js` with your own credentials.
 2. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.
 
 ## Usage
@@ -15,5 +15,5 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 - Login through `login.html` to access the respective dashboard.
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 
-Firebase configuration snippets are included in the HTML files and must be customized for your own project.
+The Firebase configuration is centralized in `firebaseConfig.js`. Update this file with your project details before using the app.
 

--- a/browse-pros.html
+++ b/browse-pros.html
@@ -24,19 +24,9 @@
   </main>
 
   <script type="module">
+    import { firebaseConfig } from './firebaseConfig.js';
     import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
     import { getFirestore, collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
-
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
 
     const app = initializeApp(firebaseConfig);
     const db  = getFirestore(app);

--- a/create-profile.html
+++ b/create-profile.html
@@ -69,21 +69,11 @@
 
   <!-- Firebase profile creation logic -->
   <script type="module">
+    import { firebaseConfig } from './firebaseConfig.js';
     import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
     import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
     import { getFirestore, doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
     import { getStorage, ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
-
-    const firebaseConfig = {
-      apiKey: 'AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo',
-      authDomain: 'tradestone-efb30.firebaseapp.com',
-      databaseURL: 'https://tradestone-efb30-default-rtdb.firebaseio.com',
-      projectId: 'tradestone-efb30',
-      storageBucket: 'tradestone-efb30.firebasestorage.app',
-      messagingSenderId: '761717818779',
-      appId: '1:761717818779:web:05287865a076dbfed68d3e',
-      measurementId: 'G-TM9DK5H25J'
-    };
 
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);

--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,0 +1,10 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  databaseURL: "YOUR_DATABASE_URL",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+  measurementId: "YOUR_MEASUREMENT_ID"
+};

--- a/login.html
+++ b/login.html
@@ -52,20 +52,10 @@
 
   <!-- Firebase login logic -->
   <script type="module">
+    import { firebaseConfig } from './firebaseConfig.js';
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
     import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
     import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
-
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
 
     const app  = initializeApp(firebaseConfig);
     const auth = getAuth(app);

--- a/personal-dashboard.html
+++ b/personal-dashboard.html
@@ -19,20 +19,10 @@
 
   <!-- Firebase and Auth guard + Logout logic -->
   <script type="module">
+    import { firebaseConfig } from './firebaseConfig.js';
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
     import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
 
-    // Same config
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
 
     const app  = initializeApp(firebaseConfig);
     const auth = getAuth(app);

--- a/professional-dashboard.html
+++ b/professional-dashboard.html
@@ -19,20 +19,9 @@
 
   <!-- Firebase and Auth guard + Logout logic -->
   <script type="module">
+    import { firebaseConfig } from './firebaseConfig.js';
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
     import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
-
-    // Same config as before
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
 
     // Init
     const app  = initializeApp(firebaseConfig);

--- a/signup.html
+++ b/signup.html
@@ -61,20 +61,10 @@
 
   <!-- Firebase signup logic -->
   <script type="module">
+    import { firebaseConfig } from './firebaseConfig.js';
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
     import { getAuth, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
     import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
-
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
 
     const app  = initializeApp(firebaseConfig);
     const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- add `firebaseConfig.js` for reusable Firebase settings
- import firebase config in all HTML pages instead of hardcoding
- document editing of `firebaseConfig.js` in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684703f1a060832bb1c4628164d95a25