### PR TITLE
Improve profile sanitization

### DIFF
--- a/browse-pros.html
+++ b/browse-pros.html
@@ -46,15 +46,33 @@
       const list = document.getElementById('pro-list');
       querySnapshot.forEach(doc => {
         const data = doc.data();
+
         const card = document.createElement('div');
         card.className = 'bg-white rounded-lg shadow p-4 space-y-1';
-        card.innerHTML = `
-          <h2 class="text-lg font-bold">${data.businessName || ''}</h2>
-          <p class="text-sm text-gray-700">${data.tradeType || ''}</p>
-          <p class="text-sm text-gray-700">${data.location || ''}</p>
-          <a href="professional-profile.html?id=${doc.id}" class="text-orange-500 block">View Profile</a>
-          <a href="portfolio.html?id=${doc.id}" class="text-orange-500 block">View Portfolio</a>
-        `;
+
+        const name = document.createElement('h2');
+        name.className = 'text-lg font-bold';
+        name.textContent = data.businessName || '';
+
+        const trade = document.createElement('p');
+        trade.className = 'text-sm text-gray-700';
+        trade.textContent = data.tradeType || '';
+
+        const locationEl = document.createElement('p');
+        locationEl.className = 'text-sm text-gray-700';
+        locationEl.textContent = data.location || '';
+
+        const profileLink = document.createElement('a');
+        profileLink.href = `professional-profile.html?id=${doc.id}`;
+        profileLink.className = 'text-orange-500 block';
+        profileLink.textContent = 'View Profile';
+
+        const portfolioLink = document.createElement('a');
+        portfolioLink.href = `portfolio.html?id=${doc.id}`;
+        portfolioLink.className = 'text-orange-500 block';
+        portfolioLink.textContent = 'View Portfolio';
+
+        card.append(name, trade, locationEl, profileLink, portfolioLink);
         list.appendChild(card);
       });
     }

--- a/portfolio.html
+++ b/portfolio.html
@@ -20,7 +20,49 @@
 
   <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
     <h2 class="text-xl font-semibold mb-2">Portfolio</h2>
-    <p class="text-gray-700">Portfolio content coming soon.</p>
+    <div id="portfolio-images" class="grid grid-cols-2 gap-4"></div>
   </main>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
+    import { getFirestore, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+
+    const firebaseConfig = {
+      apiKey: 'AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo',
+      authDomain: 'tradestone-efb30.firebaseapp.com',
+      databaseURL: 'https://tradestone-efb30-default-rtdb.firebaseio.com',
+      projectId: 'tradestone-efb30',
+      storageBucket: 'tradestone-efb30.appspot.com',
+      messagingSenderId: '761717818779',
+      appId: '1:761717818779:web:05287865a076dbfed68d3e',
+      measurementId: 'G-TM9DK5H25J'
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db  = getFirestore(app);
+
+    async function loadPortfolio() {
+      const params = new URLSearchParams(window.location.search);
+      const id = params.get('id');
+      if (!id) return;
+
+      const docSnap = await getDoc(doc(db, 'profiles', id));
+      if (!docSnap.exists()) return;
+
+      const data = docSnap.data();
+      const container = document.getElementById('portfolio-images');
+      if (Array.isArray(data.portfolioUrls)) {
+        data.portfolioUrls.forEach(url => {
+          const img = document.createElement('img');
+          img.src = url;
+          img.alt = 'Portfolio image';
+          img.className = 'w-full h-32 object-cover rounded';
+          container.appendChild(img);
+        });
+      }
+    }
+
+    loadPortfolio();
+  </script>
 </body>
 </html>

--- a/professional-profile.html
+++ b/professional-profile.html
@@ -20,7 +20,74 @@
 
   <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
     <h2 class="text-xl font-semibold mb-2">Professional Profile</h2>
-    <p class="text-gray-700">Profile details coming soon.</p>
+    <div id="profile-details" class="space-y-2"></div>
   </main>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
+    import { getFirestore, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+
+    const firebaseConfig = {
+      apiKey: 'AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo',
+      authDomain: 'tradestone-efb30.firebaseapp.com',
+      databaseURL: 'https://tradestone-efb30-default-rtdb.firebaseio.com',
+      projectId: 'tradestone-efb30',
+      storageBucket: 'tradestone-efb30.appspot.com',
+      messagingSenderId: '761717818779',
+      appId: '1:761717818779:web:05287865a076dbfed68d3e',
+      measurementId: 'G-TM9DK5H25J'
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db  = getFirestore(app);
+
+    async function loadProfile() {
+      const params = new URLSearchParams(window.location.search);
+      const id = params.get('id');
+      if (!id) return;
+
+      const docSnap = await getDoc(doc(db, 'profiles', id));
+      if (!docSnap.exists()) return;
+
+      const data = docSnap.data();
+      const container = document.getElementById('profile-details');
+
+      if (data.logoUrl) {
+        const img = document.createElement('img');
+        img.src = data.logoUrl;
+        img.alt = data.businessName || 'Logo';
+        img.className = 'w-32 h-32 mx-auto object-contain';
+        container.appendChild(img);
+      }
+
+      const name = document.createElement('h3');
+      name.className = 'text-lg font-bold';
+      name.textContent = data.businessName || '';
+      container.appendChild(name);
+
+      if (data.tradeType) {
+        const trade = document.createElement('p');
+        trade.className = 'text-sm text-gray-700';
+        trade.textContent = data.tradeType;
+        container.appendChild(trade);
+      }
+
+      if (data.location) {
+        const loc = document.createElement('p');
+        loc.className = 'text-sm text-gray-700';
+        loc.textContent = data.location;
+        container.appendChild(loc);
+      }
+
+      if (data.description) {
+        const desc = document.createElement('p');
+        desc.className = 'text-sm text-gray-700';
+        desc.textContent = data.description;
+        container.appendChild(desc);
+      }
+    }
+
+    loadProfile();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid innerHTML when listing professionals
- add profile details page using DOM APIs
- show portfolio images safely

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684703fc5f10832b9b4eeda86fa40155