### PR TITLE
Add bottom navigation snippet

### DIFF
--- a/bottom-nav.html
+++ b/bottom-nav.html
@@ -1,0 +1,32 @@
+<nav class="fixed bottom-0 inset-x-0 bg-white border-t flex justify-around py-2">
+  <a href="index.html" class="flex flex-col items-center text-orange-500">
+    <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M3 12l9-9 9 9h-3v9h-12v-9h-3z"/>
+    </svg>
+    <span class="text-xs">Home</span>
+  </a>
+  <a href="#" class="flex flex-col items-center text-gray-600">
+    <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M4 4h16v3h-16v-3zm0 5h16v3h-16v-3zm0 5h16v3h-16v-3z"/>
+    </svg>
+    <span class="text-xs">Marketplace</span>
+  </a>
+  <a href="#" class="flex flex-col items-center text-gray-600">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mb-1 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+    </svg>
+    <span class="text-xs">Post</span>
+  </a>
+  <a href="#" class="flex flex-col items-center text-gray-600">
+    <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M4 4h16v12h-4l-4 4-4-4h-4z"/>
+    </svg>
+    <span class="text-xs">Messages</span>
+  </a>
+  <a href="login.html" class="flex flex-col items-center text-gray-600">
+    <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
+    </svg>
+    <span class="text-xs">Profile</span>
+  </a>
+</nav>

--- a/index.html
+++ b/index.html
@@ -117,42 +117,14 @@
   </section>
 
   <!-- Bottom Navigation Bar -->
-  <nav class="fixed bottom-0 inset-x-0 bg-white border-t flex justify-around py-2">
-    <a href="index.html" class="flex flex-col items-center text-orange-500">
-      <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M3 12l9-9 9 9h-3v9h-12v-9h-3z"/>
-      </svg>
-      <span class="text-xs">Home</span>
-    </a>
-    <a href="#" class="flex flex-col items-center text-gray-600">
-      <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M4 4h16v3h-16v-3zm0 5h16v3h-16v-3zm0 5h16v3h-16v-3z"/>
-      </svg>
-      <span class="text-xs">Marketplace</span>
-    </a>
-    <a href="#" class="flex flex-col items-center text-gray-600">
-      <svg xmlns="http://www.w3.org/2000/svg"
-           class="h-6 w-6 mb-1 text-gray-600"
-           fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-      </svg>
-      <span class="text-xs">Post</span>
-    </a>
-    <a href="#" class="flex flex-col items-center text-gray-600">
-      <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M4 4h16v12h-4l-4 4-4-4h-4z"/>
-      </svg>
-      <span class="text-xs">Messages</span>
-    </a>
-    <a href="login.html" class="flex flex-col items-center text-gray-600">
-      <svg class="h-6 w-6 mb-1" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5  
-                 5 2.3 5 5 5zm0 2c-3.3 0-10  
-                 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
-      </svg>
-      <span class="text-xs">Profile</span>
-    </a>
-  </nav>
+  <div id="bottom-nav"></div>
+  <script>
+    fetch('bottom-nav.html')
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('bottom-nav').innerHTML = html;
+      });
+  </script>
 
   <!-- Mobile menu toggle script -->
   <script>

--- a/personal-dashboard.html
+++ b/personal-dashboard.html
@@ -50,5 +50,14 @@
       window.location.href = 'login.html';
     });
   </script>
+  <!-- Bottom Navigation Bar -->
+  <div id="bottom-nav"></div>
+  <script>
+    fetch('bottom-nav.html')
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('bottom-nav').innerHTML = html;
+      });
+  </script>
 </body>
 </html>

--- a/professional-dashboard.html
+++ b/professional-dashboard.html
@@ -53,5 +53,14 @@
       window.location.href = 'login.html';
     });
   </script>
+  <!-- Bottom Navigation Bar -->
+  <div id="bottom-nav"></div>
+  <script>
+    fetch('bottom-nav.html')
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('bottom-nav').innerHTML = html;
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract bottom navigation markup into `bottom-nav.html`
- load the navigation snippet in `index.html`
- reuse bottom navigation on personal and professional dashboards

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68470bb0aeb4832ba48eb651526373b7