### PR TITLE
Centralize Firebase initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 
 ## Setup
 
-1. Ensure you have a Firebase project and replace the configuration found in the HTML files with your own credentials.
-2. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.
+1. Create a Firebase project and copy its configuration.
+2. Edit `firebase-init.js` in the project root and replace the placeholder credentials with your own.
+3. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.
 
 ## Usage
 
@@ -15,5 +16,5 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 - Login through `login.html` to access the respective dashboard.
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 
-Firebase configuration snippets are included in the HTML files and must be customized for your own project.
+All pages import `firebase-init.js` which centralizes Firebase initialization. Update that file with your credentials and the app will use them across every page.
 

--- a/browse-pros.html
+++ b/browse-pros.html
@@ -24,22 +24,10 @@
   </main>
 
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    import { getFirestore, collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+    import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+    import { initFirebase } from './firebase-init.js';
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    const app = initializeApp(firebaseConfig);
-    const db  = getFirestore(app);
+    const { db } = initFirebase();
 
     async function loadProfessionals() {
       const querySnapshot = await getDocs(collection(db, 'profiles'));

--- a/create-profile.html
+++ b/create-profile.html
@@ -69,26 +69,12 @@
 
   <!-- Firebase profile creation logic -->
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
-    import { getFirestore, doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
-    import { getStorage, ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+    import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+    import { ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+    import { initFirebase } from './firebase-init.js';
 
-    const firebaseConfig = {
-      apiKey: 'AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo',
-      authDomain: 'tradestone-efb30.firebaseapp.com',
-      databaseURL: 'https://tradestone-efb30-default-rtdb.firebaseio.com',
-      projectId: 'tradestone-efb30',
-      storageBucket: 'tradestone-efb30.appspot.com',
-      messagingSenderId: '761717818779',
-      appId: '1:761717818779:web:05287865a076dbfed68d3e',
-      measurementId: 'G-TM9DK5H25J'
-    };
-
-    const app = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
-    const db = getFirestore(app);
-    const storage = getStorage(app);
+    const { auth, db, storage } = initFirebase();
 
     onAuthStateChanged(auth, user => {
       if (!user) {

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,0 +1,35 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+import { getStorage } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+
+// Replace these credentials with your Firebase project configuration
+const firebaseConfig = {
+  apiKey: 'AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo',
+  authDomain: 'tradestone-efb30.firebaseapp.com',
+  databaseURL: 'https://tradestone-efb30-default-rtdb.firebaseio.com',
+  projectId: 'tradestone-efb30',
+  storageBucket: 'tradestone-efb30.appspot.com',
+  messagingSenderId: '761717818779',
+  appId: '1:761717818779:web:05287865a076dbfed68d3e',
+  measurementId: 'G-TM9DK5H25J'
+};
+
+let services;
+
+/**
+ * Initialize Firebase app and return common services.
+ * Subsequent calls return the same instances.
+ */
+export function initFirebase() {
+  if (!services) {
+    const app = initializeApp(firebaseConfig);
+    services = {
+      app,
+      auth: getAuth(app),
+      db: getFirestore(app),
+      storage: getStorage(app)
+    };
+  }
+  return services;
+}

--- a/login.html
+++ b/login.html
@@ -52,24 +52,11 @@
 
   <!-- Firebase login logic -->
   <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
-    import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
-    import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    import { signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    import { initFirebase } from './firebase-init.js';
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    const app  = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
-    const db   = getFirestore(app);
+    const { auth, db } = initFirebase();
 
     const form = document.getElementById('login-form');
     form.addEventListener('submit', async e => {

--- a/personal-dashboard.html
+++ b/personal-dashboard.html
@@ -19,23 +19,10 @@
 
   <!-- Firebase and Auth guard + Logout logic -->
   <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
-    import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { initFirebase } from './firebase-init.js';
 
-    // Same config
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    const app  = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
+    const { auth } = initFirebase();
 
     onAuthStateChanged(auth, user => {
       if (!user) {

--- a/portfolio.html
+++ b/portfolio.html
@@ -24,22 +24,10 @@
   </main>
 
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    import { getStorage, ref, listAll, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+    import { ref, listAll, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+    import { initFirebase } from './firebase-init.js';
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    const app = initializeApp(firebaseConfig);
-    const storage = getStorage(app);
+    const { storage } = initFirebase();
 
     const params = new URLSearchParams(window.location.search);
     const id = params.get('id');

--- a/professional-dashboard.html
+++ b/professional-dashboard.html
@@ -19,24 +19,10 @@
 
   <!-- Firebase and Auth guard + Logout logic -->
   <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
-    import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { initFirebase } from './firebase-init.js';
 
-    // Same config as before
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    // Init
-    const app  = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
+    const { auth } = initFirebase();
 
     // Redirect if not logged in, otherwise show email
     onAuthStateChanged(auth, user => {

--- a/professional-profile.html
+++ b/professional-profile.html
@@ -27,22 +27,10 @@
   </main>
 
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    import { getFirestore, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+    import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+    import { initFirebase } from './firebase-init.js';
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    const app = initializeApp(firebaseConfig);
-    const db  = getFirestore(app);
+    const { db } = initFirebase();
 
     const params = new URLSearchParams(window.location.search);
     const id = params.get('id');

--- a/signup.html
+++ b/signup.html
@@ -61,24 +61,11 @@
 
   <!-- Firebase signup logic -->
   <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js";
-    import { getAuth, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
-    import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    import { createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { doc, setDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    import { initFirebase } from './firebase-init.js';
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-
-    const app  = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
-    const db   = getFirestore(app);
+    const { auth, db } = initFirebase();
 
     const form = document.getElementById('signup-form');
     form.addEventListener('submit', async e => {


### PR DESCRIPTION
## Summary
- add `firebase-init.js` module exporting `initFirebase`
- update all HTML files to import and use the new initializer
- document the new configuration location in `README`

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68470bb74888832ba142b95400df0414