### PR TITLE
Improve login flow and Firebase setup

### DIFF
--- a/login.html
+++ b/login.html
@@ -52,11 +52,25 @@
 
   <!-- Firebase login logic -->
   <script type="module">
-    import { signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { onAuthStateChanged, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
     import { doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
     import { initFirebase } from './firebase-init.js';
 
     const { auth, db } = initFirebase();
+
+    onAuthStateChanged(auth, async user => {
+      if (user) {
+        const snap = await getDoc(doc(db, 'users', user.uid));
+        if (snap.exists()) {
+          const { accountType } = snap.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          window.location.href = 'index.html';
+        }
+      }
+    });
 
     const form = document.getElementById('login-form');
     form.addEventListener('submit', async e => {

--- a/marketplace.html
+++ b/marketplace.html
@@ -57,18 +57,8 @@
   </nav>
 
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-    const app = initializeApp(firebaseConfig);
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
   </script>
 </body>
 </html>

--- a/messages.html
+++ b/messages.html
@@ -57,18 +57,8 @@
   </nav>
 
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-    const app = initializeApp(firebaseConfig);
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
   </script>
 </body>
 </html>

--- a/post.html
+++ b/post.html
@@ -57,18 +57,8 @@
   </nav>
 
   <script type="module">
-    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app.js';
-    const firebaseConfig = {
-      apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
-      authDomain: "tradestone-efb30.firebaseapp.com",
-      databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
-      projectId: "tradestone-efb30",
-      storageBucket: "tradestone-efb30.appspot.com",
-      messagingSenderId: "761717818779",
-      appId: "1:761717818779:web:05287865a076dbfed68d3e",
-      measurementId: "G-TM9DK5H25J"
-    };
-    const app = initializeApp(firebaseConfig);
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
   </script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -79,7 +79,7 @@
         if (accountType === 'professional') {
           window.location.href = 'create-profile.html';
         } else {
-          window.location.href = 'login.html';
+          window.location.href = 'personal-dashboard.html';
         }
       } catch(err) {
         alert(err.message);


### PR DESCRIPTION
## Summary
- keep personal accounts logged in after sign up
- redirect logged-in users away from the login page
- centralize Firebase init on remaining pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68471bd7cef4832bbde922a7de47a3af