### PR TITLE
Add password confirmation

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -41,6 +41,11 @@
         <input id="password" name="password" type="password" required
                class="w-full p-2 border rounded"/>
       </div>
+      <div>
+        <label for="confirmPassword" class="block mb-1">Confirm Password</label>
+        <input id="confirmPassword" name="confirmPassword" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
       <button type="submit"
               class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
         Sign Up
@@ -92,7 +97,12 @@
       e.preventDefault();
       const email       = form.email.value;
       const password    = form.password.value;
+      const confirm     = form.confirmPassword.value;
       const accountType = form.accountType.value;
+      if (password !== confirm) {
+        alert('Passwords do not match.');
+        return;
+      }
       try {
         const { user } = await createUserWithEmailAndPassword(auth, email, password);
         await setDoc(doc(db, 'users', user.uid), {


### PR DESCRIPTION
## Summary
- add a confirm password field to `signup.html`
- validate passwords match before creating the user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848306baa20832b90220f174e6a2fce