### PR TITLE
Add in-page error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 - Login through `login.html` to access the respective dashboard.
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 
+Error messages are now shown directly within the forms instead of browser alert dialogs.
+
 All pages import `firebase-init.js` which centralizes Firebase initialization. Update that file with your credentials and the app will use them across every page.
 

--- a/account-settings.html
+++ b/account-settings.html
@@ -44,10 +44,22 @@
     </form>
 
     <button id="delete-account-btn" class="w-full py-2 bg-red-500 text-white rounded">Delete Account</button>
+    <div id="error-msg" class="text-red-500 text-center"></div>
+    <div id="success-msg" class="text-green-500 text-center"></div>
   </main>
 
   <div class="text-center mt-6">
     <a href="professional-dashboard.html" class="text-orange-500 font-medium">Back to Dashboard</a>
+  </div>
+
+  <div id="confirm-modal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
+    <div class="bg-white p-4 rounded text-center space-y-4">
+      <p>Delete your account and profile? This cannot be undone.</p>
+      <div class="flex justify-end space-x-2">
+        <button id="cancel-delete" class="px-3 py-1 border rounded">Cancel</button>
+        <button id="confirm-delete" class="px-3 py-1 bg-red-500 text-white rounded">Delete</button>
+      </div>
+    </div>
   </div>
 
   <script type="module">
@@ -73,25 +85,32 @@
       }
     });
 
+    const errorEl = document.getElementById('error-msg');
+    const successEl = document.getElementById('success-msg');
+
     document.getElementById('update-email-form').addEventListener('submit', async e => {
       e.preventDefault();
+      errorEl.textContent = '';
+      successEl.textContent = '';
       const newEmail = e.target.newEmail.value;
       try {
         await updateEmail(auth.currentUser, newEmail);
-        alert('Email updated');
+        successEl.textContent = 'Email updated';
       } catch (err) {
-        alert(err.message);
+        errorEl.textContent = err.message;
       }
     });
 
     document.getElementById('update-password-form').addEventListener('submit', async e => {
       e.preventDefault();
+      errorEl.textContent = '';
+      successEl.textContent = '';
       const newPassword = e.target.newPassword.value;
       try {
         await updatePassword(auth.currentUser, newPassword);
-        alert('Password updated');
+        successEl.textContent = 'Password updated';
       } catch (err) {
-        alert(err.message);
+        errorEl.textContent = err.message;
       }
     });
 
@@ -104,17 +123,30 @@
       await updateDoc(doc(db, 'users', auth.currentUser.uid), { notifications: prefs }, { merge: true });
     });
 
-    document.getElementById('delete-account-btn').addEventListener('click', async () => {
+    const modal = document.getElementById('confirm-modal');
+    const cancelBtn = document.getElementById('cancel-delete');
+    const confirmBtn = document.getElementById('confirm-delete');
+
+    document.getElementById('delete-account-btn').addEventListener('click', () => {
+      modal.classList.remove('hidden');
+      errorEl.textContent = '';
+      successEl.textContent = '';
+    });
+
+    cancelBtn.addEventListener('click', () => {
+      modal.classList.add('hidden');
+    });
+
+    confirmBtn.addEventListener('click', async () => {
+      modal.classList.add('hidden');
       if (!auth.currentUser) return;
-      const confirmation = confirm('Delete your account and profile? This cannot be undone.');
-      if (!confirmation) return;
       try {
         await deleteDoc(doc(db, 'profiles', auth.currentUser.uid));
         await deleteDoc(doc(db, 'users', auth.currentUser.uid));
         await deleteUser(auth.currentUser);
         window.location.href = 'signup.html';
       } catch (err) {
-        alert(err.message);
+        errorEl.textContent = err.message;
       }
     });
   </script>

--- a/login.html
+++ b/login.html
@@ -33,6 +33,7 @@
         Log In
       </button>
     </form>
+    <div id="error-msg" class="text-red-500 mt-2"></div>
     <p class="mt-4 text-center text-sm">
       Don’t have an account?
       <a href="signup.html" class="text-orange-500 font-medium">Sign up</a>
@@ -79,8 +80,10 @@
     });
 
     const form = document.getElementById('login-form');
+    const errorEl = document.getElementById('error-msg');
     form.addEventListener('submit', async e => {
       e.preventDefault();
+      errorEl.textContent = '';
       const email    = form.email.value;
       const password = form.password.value;
       try {
@@ -95,7 +98,7 @@
           window.location.href = 'index.html';
         }
       } catch(err) {
-        alert(err.message);
+        errorEl.textContent = err.message;
       }
     });
   </script>

--- a/signup.html
+++ b/signup.html
@@ -51,6 +51,7 @@
         Sign Up
       </button>
     </form>
+    <div id="error-msg" class="text-red-500 mt-2"></div>
   </main>
 
   <!-- Home button -->
@@ -93,14 +94,16 @@
     });
 
     const form = document.getElementById('signup-form');
+    const errorEl = document.getElementById('error-msg');
     form.addEventListener('submit', async e => {
       e.preventDefault();
+      errorEl.textContent = '';
       const email       = form.email.value;
       const password    = form.password.value;
       const confirm     = form.confirmPassword.value;
       const accountType = form.accountType.value;
       if (password !== confirm) {
-        alert('Passwords do not match.');
+        errorEl.textContent = 'Passwords do not match.';
         return;
       }
       try {
@@ -115,7 +118,7 @@
           window.location.href = 'personal-dashboard.html';
         }
       } catch(err) {
-        alert(err.message);
+        errorEl.textContent = err.message;
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- add error message areas for login, signup, and account settings
- show Firebase errors in page instead of alert dialogs
- display success messages and a custom delete confirmation modal in account settings
- document new error message behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483a6f5d20832b970bcca49a272c1d