### PR TITLE
Add in-page error handling and modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 - Login through `login.html` to access the respective dashboard.
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 
+Error messages for login, signup and account settings now appear directly on the page instead of using JavaScript alert boxes.
+
 All pages import `firebase-init.js` which centralizes Firebase initialization. Update that file with your credentials and the app will use them across every page.
 

--- a/account-settings.html
+++ b/account-settings.html
@@ -23,6 +23,8 @@
       </label>
       <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Update Email</button>
     </form>
+    <div id="success-msg" class="text-green-500"></div>
+    <div id="error-msg" class="text-red-500"></div>
 
     <form id="update-password-form" class="space-y-2">
       <label class="block">New Password
@@ -30,6 +32,8 @@
       </label>
       <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Update Password</button>
     </form>
+    <div id="success-msg" class="text-green-500"></div>
+    <div id="error-msg" class="text-red-500"></div>
 
     <form id="notif-form" class="space-y-2">
       <p class="font-medium">Notifications</p>
@@ -42,8 +46,19 @@
         <span>SMS Updates</span>
       </label>
     </form>
+    <div id="error-msg" class="text-red-500"></div>
 
     <button id="delete-account-btn" class="w-full py-2 bg-red-500 text-white rounded">Delete Account</button>
+
+    <div id="delete-modal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden">
+      <div class="bg-white p-4 rounded">
+        <p class="mb-4">Delete your account and profile? This cannot be undone.</p>
+        <div class="flex justify-end gap-2">
+          <button id="cancel-delete" class="px-3 py-1 bg-gray-300 rounded">Cancel</button>
+          <button id="confirm-delete" class="px-3 py-1 bg-red-500 text-white rounded">Delete</button>
+        </div>
+      </div>
+    </div>
   </main>
 
   <div class="text-center mt-6">
@@ -73,25 +88,32 @@
       }
     });
 
+    const errorDiv = document.getElementById('error-msg');
+    const successDiv = document.getElementById('success-msg');
+
     document.getElementById('update-email-form').addEventListener('submit', async e => {
       e.preventDefault();
+      errorDiv.textContent = '';
+      successDiv.textContent = '';
       const newEmail = e.target.newEmail.value;
       try {
         await updateEmail(auth.currentUser, newEmail);
-        alert('Email updated');
+        successDiv.textContent = 'Email updated';
       } catch (err) {
-        alert(err.message);
+        document.getElementById('error-msg').textContent = err.message;
       }
     });
 
     document.getElementById('update-password-form').addEventListener('submit', async e => {
       e.preventDefault();
+      errorDiv.textContent = '';
+      successDiv.textContent = '';
       const newPassword = e.target.newPassword.value;
       try {
         await updatePassword(auth.currentUser, newPassword);
-        alert('Password updated');
+        successDiv.textContent = 'Password updated';
       } catch (err) {
-        alert(err.message);
+        document.getElementById('error-msg').textContent = err.message;
       }
     });
 
@@ -104,17 +126,25 @@
       await updateDoc(doc(db, 'users', auth.currentUser.uid), { notifications: prefs }, { merge: true });
     });
 
-    document.getElementById('delete-account-btn').addEventListener('click', async () => {
+    const modal = document.getElementById('delete-modal');
+    document.getElementById('delete-account-btn').addEventListener('click', () => {
+      modal.classList.remove('hidden');
+    });
+
+    document.getElementById('cancel-delete').addEventListener('click', () => {
+      modal.classList.add('hidden');
+    });
+
+    document.getElementById('confirm-delete').addEventListener('click', async () => {
       if (!auth.currentUser) return;
-      const confirmation = confirm('Delete your account and profile? This cannot be undone.');
-      if (!confirmation) return;
+      modal.classList.add('hidden');
       try {
         await deleteDoc(doc(db, 'profiles', auth.currentUser.uid));
         await deleteDoc(doc(db, 'users', auth.currentUser.uid));
         await deleteUser(auth.currentUser);
         window.location.href = 'signup.html';
       } catch (err) {
-        alert(err.message);
+        document.getElementById('error-msg').textContent = err.message;
       }
     });
   </script>

--- a/edit-profile.html
+++ b/edit-profile.html
@@ -53,6 +53,16 @@
       <h3 class="text-lg font-semibold mb-2 text-center">Your Portfolio</h3>
       <div id="image-grid" class="grid grid-cols-1 gap-4"></div>
     </div>
+
+    <div id="img-delete-modal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden">
+      <div class="bg-white p-4 rounded">
+        <p class="mb-4">Delete this image?</p>
+        <div class="flex justify-end gap-2">
+          <button id="img-cancel" type="button" class="px-3 py-1 bg-gray-300 rounded">Cancel</button>
+          <button id="img-confirm" type="button" class="px-3 py-1 bg-red-500 text-white rounded">Delete</button>
+        </div>
+      </div>
+    </div>
   </main>
 
   <script type="module">
@@ -64,7 +74,24 @@
     const { auth, db, storage } = initFirebase();
     const form = document.getElementById('profile-form');
     const grid = document.getElementById('image-grid');
+    const imgModal = document.getElementById('img-delete-modal');
+    const imgCancel = document.getElementById('img-cancel');
+    const imgConfirm = document.getElementById('img-confirm');
     let currentUser;
+    let itemToDelete = null;
+
+    imgCancel.addEventListener('click', () => {
+      itemToDelete = null;
+      imgModal.classList.add('hidden');
+    });
+
+    imgConfirm.addEventListener('click', async () => {
+      if (!itemToDelete) return;
+      await deleteObject(itemToDelete);
+      itemToDelete = null;
+      imgModal.classList.add('hidden');
+      await loadImages();
+    });
 
     onAuthStateChanged(auth, async user => {
       if (!user) {
@@ -133,11 +160,9 @@
           const del = document.createElement('button');
           del.textContent = 'Delete';
           del.className = 'absolute top-1 right-1 bg-red-500 text-white text-xs px-1 rounded';
-          del.addEventListener('click', async () => {
-            if (confirm('Delete this image?')) {
-              await deleteObject(item);
-              await loadImages();
-            }
+          del.addEventListener('click', () => {
+            itemToDelete = item;
+            imgModal.classList.remove('hidden');
           });
           container.appendChild(img);
           container.appendChild(del);

--- a/login.html
+++ b/login.html
@@ -33,6 +33,7 @@
         Log In
       </button>
     </form>
+    <div id="error-msg" class="text-red-500"></div>
     <p class="mt-4 text-center text-sm">
       Don’t have an account?
       <a href="signup.html" class="text-orange-500 font-medium">Sign up</a>
@@ -79,8 +80,10 @@
     });
 
     const form = document.getElementById('login-form');
+    const errorDiv = document.getElementById('error-msg');
     form.addEventListener('submit', async e => {
       e.preventDefault();
+      errorDiv.textContent = '';
       const email    = form.email.value;
       const password = form.password.value;
       try {
@@ -95,7 +98,7 @@
           window.location.href = 'index.html';
         }
       } catch(err) {
-        alert(err.message);
+        errorDiv.textContent = err.message;
       }
     });
   </script>

--- a/signup.html
+++ b/signup.html
@@ -51,6 +51,7 @@
         Sign Up
       </button>
     </form>
+    <div id="error-msg" class="text-red-500"></div>
   </main>
 
   <!-- Home button -->
@@ -93,14 +94,16 @@
     });
 
     const form = document.getElementById('signup-form');
+    const errorDiv = document.getElementById('error-msg');
     form.addEventListener('submit', async e => {
       e.preventDefault();
+      errorDiv.textContent = '';
       const email       = form.email.value;
       const password    = form.password.value;
       const confirm     = form.confirmPassword.value;
       const accountType = form.accountType.value;
       if (password !== confirm) {
-        alert('Passwords do not match.');
+        errorDiv.textContent = 'Passwords do not match.';
         return;
       }
       try {
@@ -115,7 +118,7 @@
           window.location.href = 'personal-dashboard.html';
         }
       } catch(err) {
-        alert(err.message);
+        errorDiv.textContent = err.message;
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- show login, signup, and account settings errors inline instead of alerts
- add success and deletion modals on account settings
- replace image delete confirm with modal in edit profile
- document new error messages in README

## Testing
- `grep -n "alert(" -r *.html`
- `grep -n "confirm(" -r *.html`

------
https://chatgpt.com/codex/tasks/task_e_68483a4cc70c832b8ccaa70f6c37afa0