### PR TITLE
Improve responsive navigation

### DIFF
--- a/header.html
+++ b/header.html
@@ -10,7 +10,7 @@
   <!-- Right side icons -->
   <div class="ml-auto flex items-center space-x-4">
     <!-- Burger menu button -->
-    <button id="burger-btn" onclick="document.getElementById('burger-menu').classList.toggle('hidden')" class="focus:outline-none">
+    <button id="burger-btn" onclick="document.getElementById('burger-menu').classList.toggle('translate-x-full'); document.getElementById('burger-menu').classList.toggle('hidden');" class="focus:outline-none sm:hidden">
       <svg class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
       </svg>
@@ -24,7 +24,7 @@
   </div>
 
   <!-- Dropdown menu -->
-  <div id="burger-menu" class="hidden absolute right-4 top-full mt-2 bg-white border rounded-md shadow-md w-40">
+  <div id="burger-menu" class="hidden fixed inset-y-0 right-0 w-64 transform translate-x-full transition-transform bg-white border-l border-gray-200 p-4 space-y-2 sm:static sm:translate-x-0 sm:flex sm:items-center sm:space-x-4 sm:space-y-0 sm:p-0 sm:border-0 sm:bg-transparent">
     <a href="index.html" class="block px-4 py-2 hover:bg-gray-100">Home</a>
     <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-100">Marketplace</a>
     <a href="post.html" class="block px-4 py-2 hover:bg-gray-100">Post</a>


### PR DESCRIPTION
## Summary
- show the burger icon only on small screens
- make the dropdown menu a slide-out panel
- toggle panel visibility and translation via button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68483dbd59b0832bad1f35a93c036c04