### PR TITLE
Add separate login and signup pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 
 ## Usage
 
-- Sign up via `signup.html` selecting either a personal or professional account.
-- Login through `login.html` to access the respective dashboard.
+- Sign up via `professional-signup.html` or `personal-signup.html` depending on the desired account type.
+- Login through `professional-login.html` or `personal-login.html` to access the respective dashboard.
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 - Error messages for login, signup, and account settings now appear directly on the page instead of using browser alert dialogs.
 

--- a/header.html
+++ b/header.html
@@ -30,6 +30,7 @@
     <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-100">Marketplace</a>
     <a href="post.html" class="block px-4 py-2 hover:bg-gray-100">Post</a>
     <a href="messages.html" class="block px-4 py-2 hover:bg-gray-100">Messages</a>
-    <a href="login.html" class="block px-4 py-2 hover:bg-gray-100">Login</a>
+    <a href="professional-login.html" class="block px-4 py-2 hover:bg-gray-100">Professional Login</a>
+    <a href="personal-login.html" class="block px-4 py-2 hover:bg-gray-100">Personal Login</a>
   </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -28,14 +28,22 @@ Buy and sell excess materials, win more work, and connect with the right clients
 
   <!-- Call-to-action for Login / Sign Up -->
   <section class="px-4 pb-8 text-center">
-    <div class="flex flex-col sm:flex-row justify-center gap-4">
-      <a href="signup.html"
+    <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
+      <a href="professional-signup.html"
          class="px-8 py-4 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold focus:ring-2 focus:ring-orange-500">
-        Sign Up
+        Professional Sign Up
       </a>
-      <a href="login.html"
+      <a href="personal-signup.html"
+         class="px-8 py-4 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold focus:ring-2 focus:ring-orange-500">
+        Personal Sign Up
+      </a>
+      <a href="professional-login.html"
          class="px-8 py-4 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold focus:ring-2 focus:ring-orange-500">
-        Log In
+        Professional Login
+      </a>
+      <a href="personal-login.html"
+         class="px-8 py-4 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold focus:ring-2 focus:ring-orange-500">
+        Personal Login
       </a>
     </div>
   </section>

--- a/personal-login.html
+++ b/personal-login.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Personal Login – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h1 class="text-2xl font-bold mb-6 text-center">Personal Login</h1>
+    <form id="login-form" class="space-y-4">
+      <div>
+        <label for="email" class="block mb-1">Email</label>
+        <input id="email" name="email" type="email" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <div>
+        <label for="password" class="block mb-1">Password</label>
+        <input id="password" name="password" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <button type="submit"
+              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
+        Log In
+      </button>
+    </form>
+    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
+    <p class="mt-4 text-center text-sm">
+      Don’t have an account?
+      <a href="personal-signup.html" class="text-orange-500 font-medium">Sign up</a>
+    </p>
+  </main>
+
+  <div class="text-center mt-6">
+    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
+      <svg xmlns="http://www.w3.org/2000/svg"
+           class="h-8 w-8"
+           fill="none"
+           viewBox="0 0 24 24"
+           stroke="currentColor"
+           stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M9 22V12h6v10"/>
+      </svg>
+    </a>
+  </div>
+
+  <script type="module">
+    // Import necessary Firebase modules
+    import { onAuthStateChanged, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    // Import your centralized Firebase initialization
+    import { initFirebase } from './firebase-init.js';
+
+    // Initialize Firebase services using your centralized function
+    const { auth, db } = initFirebase();
+
+    // Check if a user is already logged in and redirect them
+    onAuthStateChanged(auth, async user => {
+      if (user) {
+        const snap = await getDoc(doc(db, 'users', user.uid));
+        if (snap.exists()) {
+          const { accountType } = snap.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          // Fallback if user exists in auth but not in Firestore 'users' collection
+          window.location.href = 'index.html';
+        }
+      }
+    });
+
+    const form = document.getElementById('login-form');
+    const errorEl = document.getElementById('error-msg'); // Define error element
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Define email regex
+
+    // Handle form submission for login
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      errorEl.textContent = ''; // Clear previous error messages
+
+      const email = form.email.value;
+      // Validate email format using regex
+      if (!emailRegex.test(email)) {
+        errorEl.textContent = 'Please enter a valid email address.'; // Use errorEl for message
+        form.email.focus();
+        return;
+      }
+      const password = form.password.value;
+
+      try {
+        const { user } = await signInWithEmailAndPassword(auth, email, password);
+        const userDoc = await getDoc(doc(db, 'users', user.uid));
+        if (userDoc.exists()) {
+          const { accountType } = userDoc.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          // This case should ideally not happen if signup creates the user doc correctly
+          window.location.href = 'index.html';
+        }
+      } catch(err) {
+        // Display Firebase authentication errors directly on the page
+        errorEl.textContent = err.message;
+      }
+    });
+  </script>
+
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+
+</body>
+</html>

--- a/personal-signup.html
+++ b/personal-signup.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Personal Sign Up – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h1 class="text-2xl font-bold mb-6 text-center">Create Personal Account</h1>
+    <form id="signup-form" class="space-y-4">
+      <input type="hidden" name="accountType" value="personal"/>
+      <div>
+        <label for="email" class="block mb-1">Email</label>
+        <input id="email" name="email" type="email" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <div>
+        <label for="password" class="block mb-1">Password</label>
+        <input id="password" name="password" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <div>
+        <label for="confirmPassword" class="block mb-1">Confirm Password</label>
+        <input id="confirmPassword" name="confirmPassword" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <button type="submit"
+              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
+        Sign Up
+      </button>
+    </form>
+    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
+  </main>
+
+  <div class="text-center mt-6">
+    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
+      <svg xmlns="http://www.w3.org/2000/svg"
+           class="h-8 w-8"
+           fill="none"
+           viewBox="0 0 24 24"
+           stroke="currentColor"
+           stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M9 22V12h6v10"/>
+      </svg>
+    </a>
+  </div>
+
+  <script type="module">
+    // Import necessary Firebase modules
+    import { onAuthStateChanged, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { doc, setDoc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    // Import your centralized Firebase initialization
+    import { initFirebase } from './firebase-init.js';
+
+    // Initialize Firebase services using your centralized function
+    const { auth, db } = initFirebase();
+
+    // Check if a user is already logged in and redirect them
+    onAuthStateChanged(auth, async user => {
+      if (user) {
+        const snap = await getDoc(doc(db, 'users', user.uid));
+        if (snap.exists()) {
+          const { accountType } = snap.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          // Fallback if user exists in auth but not in Firestore 'users' collection
+          window.location.href = 'index.html';
+        }
+      }
+    });
+
+    const form = document.getElementById('signup-form');
+    const errorEl = document.getElementById('error-msg'); // Define error element
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Define email regex
+
+    // Handle form submission for signup
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      errorEl.textContent = ''; // Clear any previous error messages
+
+      const email       = form.email.value;
+      // Validate email format using regex
+      if (!emailRegex.test(email)) {
+        errorEl.textContent = 'Please enter a valid email address.'; // Use errorEl for message
+        form.email.focus();
+        return;
+      }
+      const password    = form.password.value;
+      const confirm     = form.confirmPassword.value;
+      const accountType = form.accountType.value;
+
+      // Validate passwords match
+      if (password !== confirm) {
+        errorEl.textContent = 'Passwords do not match.';
+        return;
+      }
+
+      try {
+        // Create user with email and password
+        const { user } = await createUserWithEmailAndPassword(auth, email, password);
+        // Save user account type and default notification settings to Firestore
+        await setDoc(doc(db, 'users', user.uid), {
+          accountType,
+          notifications: { emailUpdates: true, smsUpdates: true } // Default notifications
+        });
+
+        // Redirect based on account type
+        if (accountType === 'professional') {
+          window.location.href = 'create-profile.html';
+        } else {
+          window.location.href = 'personal-dashboard.html';
+        }
+      } catch(err) {
+        // Display Firebase authentication errors directly on the page
+        errorEl.textContent = err.message;
+      }
+    });
+  </script>
+
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+
+</body>
+</html>

--- a/professional-login.html
+++ b/professional-login.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Professional Login – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h1 class="text-2xl font-bold mb-6 text-center">Professional Login</h1>
+    <form id="login-form" class="space-y-4">
+      <div>
+        <label for="email" class="block mb-1">Email</label>
+        <input id="email" name="email" type="email" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <div>
+        <label for="password" class="block mb-1">Password</label>
+        <input id="password" name="password" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <button type="submit"
+              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
+        Log In
+      </button>
+    </form>
+    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
+    <p class="mt-4 text-center text-sm">
+      Don’t have an account?
+      <a href="professional-signup.html" class="text-orange-500 font-medium">Sign up</a>
+    </p>
+  </main>
+
+  <div class="text-center mt-6">
+    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
+      <svg xmlns="http://www.w3.org/2000/svg"
+           class="h-8 w-8"
+           fill="none"
+           viewBox="0 0 24 24"
+           stroke="currentColor"
+           stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M9 22V12h6v10"/>
+      </svg>
+    </a>
+  </div>
+
+  <script type="module">
+    // Import necessary Firebase modules
+    import { onAuthStateChanged, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    // Import your centralized Firebase initialization
+    import { initFirebase } from './firebase-init.js';
+
+    // Initialize Firebase services using your centralized function
+    const { auth, db } = initFirebase();
+
+    // Check if a user is already logged in and redirect them
+    onAuthStateChanged(auth, async user => {
+      if (user) {
+        const snap = await getDoc(doc(db, 'users', user.uid));
+        if (snap.exists()) {
+          const { accountType } = snap.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          // Fallback if user exists in auth but not in Firestore 'users' collection
+          window.location.href = 'index.html';
+        }
+      }
+    });
+
+    const form = document.getElementById('login-form');
+    const errorEl = document.getElementById('error-msg'); // Define error element
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Define email regex
+
+    // Handle form submission for login
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      errorEl.textContent = ''; // Clear previous error messages
+
+      const email = form.email.value;
+      // Validate email format using regex
+      if (!emailRegex.test(email)) {
+        errorEl.textContent = 'Please enter a valid email address.'; // Use errorEl for message
+        form.email.focus();
+        return;
+      }
+      const password = form.password.value;
+
+      try {
+        const { user } = await signInWithEmailAndPassword(auth, email, password);
+        const userDoc = await getDoc(doc(db, 'users', user.uid));
+        if (userDoc.exists()) {
+          const { accountType } = userDoc.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          // This case should ideally not happen if signup creates the user doc correctly
+          window.location.href = 'index.html';
+        }
+      } catch(err) {
+        // Display Firebase authentication errors directly on the page
+        errorEl.textContent = err.message;
+      }
+    });
+  </script>
+
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+
+</body>
+</html>

--- a/professional-signup.html
+++ b/professional-signup.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Professional Sign Up – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h1 class="text-2xl font-bold mb-6 text-center">Create Professional Account</h1>
+    <form id="signup-form" class="space-y-4">
+      <input type="hidden" name="accountType" value="professional"/>
+      <div>
+        <label for="email" class="block mb-1">Email</label>
+        <input id="email" name="email" type="email" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <div>
+        <label for="password" class="block mb-1">Password</label>
+        <input id="password" name="password" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <div>
+        <label for="confirmPassword" class="block mb-1">Confirm Password</label>
+        <input id="confirmPassword" name="confirmPassword" type="password" required
+               class="w-full p-2 border rounded"/>
+      </div>
+      <button type="submit"
+              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
+        Sign Up
+      </button>
+    </form>
+    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
+  </main>
+
+  <div class="text-center mt-6">
+    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
+      <svg xmlns="http://www.w3.org/2000/svg"
+           class="h-8 w-8"
+           fill="none"
+           viewBox="0 0 24 24"
+           stroke="currentColor"
+           stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M9 22V12h6v10"/>
+      </svg>
+    </a>
+  </div>
+
+  <script type="module">
+    // Import necessary Firebase modules
+    import { onAuthStateChanged, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
+    import { doc, setDoc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
+    // Import your centralized Firebase initialization
+    import { initFirebase } from './firebase-init.js';
+
+    // Initialize Firebase services using your centralized function
+    const { auth, db } = initFirebase();
+
+    // Check if a user is already logged in and redirect them
+    onAuthStateChanged(auth, async user => {
+      if (user) {
+        const snap = await getDoc(doc(db, 'users', user.uid));
+        if (snap.exists()) {
+          const { accountType } = snap.data();
+          window.location.href = accountType === 'professional'
+            ? 'professional-dashboard.html'
+            : 'personal-dashboard.html';
+        } else {
+          // Fallback if user exists in auth but not in Firestore 'users' collection
+          window.location.href = 'index.html';
+        }
+      }
+    });
+
+    const form = document.getElementById('signup-form');
+    const errorEl = document.getElementById('error-msg'); // Define error element
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Define email regex
+
+    // Handle form submission for signup
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      errorEl.textContent = ''; // Clear any previous error messages
+
+      const email       = form.email.value;
+      // Validate email format using regex
+      if (!emailRegex.test(email)) {
+        errorEl.textContent = 'Please enter a valid email address.'; // Use errorEl for message
+        form.email.focus();
+        return;
+      }
+      const password    = form.password.value;
+      const confirm     = form.confirmPassword.value;
+      const accountType = form.accountType.value;
+
+      // Validate passwords match
+      if (password !== confirm) {
+        errorEl.textContent = 'Passwords do not match.';
+        return;
+      }
+
+      try {
+        // Create user with email and password
+        const { user } = await createUserWithEmailAndPassword(auth, email, password);
+        // Save user account type and default notification settings to Firestore
+        await setDoc(doc(db, 'users', user.uid), {
+          accountType,
+          notifications: { emailUpdates: true, smsUpdates: true } // Default notifications
+        });
+
+        // Redirect based on account type
+        if (accountType === 'professional') {
+          window.location.href = 'create-profile.html';
+        } else {
+          window.location.href = 'personal-dashboard.html';
+        }
+      } catch(err) {
+        // Display Firebase authentication errors directly on the page
+        errorEl.textContent = err.message;
+      }
+    });
+  </script>
+
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `professional-signup.html` and `personal-signup.html` with account type preset
- add `professional-login.html` and `personal-login.html`
- expose new login links in the header
- update landing page buttons to link to the new pages
- document new pages in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68484d51053c832bba6b5a6357302e5f