### PR TITLE
Fix closing of onAuthStateChanged in dashboard

### DIFF
--- a/personal-dashboard.html
+++ b/personal-dashboard.html
@@ -39,6 +39,7 @@
         // If a user is logged in, display their email
         document.getElementById('user-email').textContent = user.email;
       }
+    });
 
     // Add event listener for the logout button
     document.getElementById('logout-btn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- properly close `onAuthStateChanged` in `personal-dashboard.html`
- keep logout handler outside of the auth state listener

## Testing
- `node --check temp_script.mjs` *(verify JS syntax)*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68485363f4a8832bb20c3fac2d952782