### PR TITLE
Add login/signup choice pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 
 ## Usage
 
-- Sign up via `signup.html` and choose whether you need a professional or personal account on that page.
-- Log in through `login.html`, which will route you to the appropriate dashboard once authenticated.
+- Sign up via `signup.html` and choose either a professional or personal account.
+- Log in through `login.html`, selecting the matching login type before entering credentials.
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 - Error messages for login, signup, and account settings now appear directly on the page instead of using browser alert dialogs.
 

--- a/header.html
+++ b/header.html
@@ -30,7 +30,7 @@
     <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-100">Marketplace</a>
     <a href="post.html" class="block px-4 py-2 hover:bg-gray-100">Post</a>
     <a href="messages.html" class="block px-4 py-2 hover:bg-gray-100">Messages</a>
-    <a href="professional-login.html" class="block px-4 py-2 hover:bg-gray-100">Professional Login</a>
-    <a href="personal-login.html" class="block px-4 py-2 hover:bg-gray-100">Personal Login</a>
+    <a href="signup.html" class="block px-4 py-2 hover:bg-gray-100">Sign Up</a>
+    <a href="login.html" class="block px-4 py-2 hover:bg-gray-100">Log In</a>
   </div>
 </header>

--- a/login.html
+++ b/login.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Log In – TradeStone</title>
+  <title>Choose Login Type – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 font-sans pb-16">
@@ -13,109 +13,14 @@
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
-    <h1 class="text-2xl font-bold mb-6 text-center">Log In</h1>
-    <form id="login-form" class="space-y-4">
-      <div>
-        <label for="email" class="block mb-1">Email</label>
-        <input id="email" name="email" type="email" required
-               class="w-full p-2 border rounded"/>
-      </div>
-      <div>
-        <label for="password" class="block mb-1">Password</label>
-        <input id="password" name="password" type="password" required
-               class="w-full p-2 border rounded"/>
-      </div>
-      <button type="submit"
-              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
-        Log In
-      </button>
-    </form>
-    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
-    <p class="mt-4 text-center text-sm">
-      Don’t have an account?
-      <a href="signup.html" class="text-orange-500 font-medium">Sign up</a>
-    </p>
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-6">
+    <h1 class="text-2xl font-bold">Log In</h1>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="professional-login.html" class="px-6 py-3 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold">Professional Login</a>
+      <a href="personal-login.html" class="px-6 py-3 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold">Personal Login</a>
+    </div>
+    <p class="text-sm">Need an account? <a href="signup.html" class="text-orange-600 font-medium">Sign up</a></p>
   </main>
-
-  <div class="text-center mt-6">
-    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
-      <svg xmlns="http://www.w3.org/2000/svg"
-           class="h-8 w-8"
-           fill="none"
-           viewBox="0 0 24 24"
-           stroke="currentColor"
-           stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round"
-              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
-        <path stroke-linecap="round" stroke-linejoin="round"
-              d="M9 22V12h6v10"/>
-      </svg>
-    </a>
-  </div>
-
-  <script type="module">
-    // Import necessary Firebase modules
-    import { onAuthStateChanged, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
-    import { doc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
-    // Import your centralized Firebase initialization
-    import { initFirebase } from './firebase-init.js';
-
-    // Initialize Firebase services using your centralized function
-    const { auth, db } = initFirebase();
-
-    // Check if a user is already logged in and redirect them
-    onAuthStateChanged(auth, async user => {
-      if (user) {
-        const snap = await getDoc(doc(db, 'users', user.uid));
-        if (snap.exists()) {
-          const { accountType } = snap.data();
-          window.location.href = accountType === 'professional'
-            ? 'professional-dashboard.html'
-            : 'personal-dashboard.html';
-        } else {
-          // Fallback if user exists in auth but not in Firestore 'users' collection
-          window.location.href = 'index.html';
-        }
-      }
-    });
-
-    const form = document.getElementById('login-form');
-    const errorEl = document.getElementById('error-msg'); // Define error element
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Define email regex
-
-    // Handle form submission for login
-    form.addEventListener('submit', async e => {
-      e.preventDefault();
-      errorEl.textContent = ''; // Clear previous error messages
-
-      const email = form.email.value;
-      // Validate email format using regex
-      if (!emailRegex.test(email)) {
-        errorEl.textContent = 'Please enter a valid email address.'; // Use errorEl for message
-        form.email.focus();
-        return;
-      }
-      const password = form.password.value;
-
-      try {
-        const { user } = await signInWithEmailAndPassword(auth, email, password);
-        const userDoc = await getDoc(doc(db, 'users', user.uid));
-        if (userDoc.exists()) {
-          const { accountType } = userDoc.data();
-          window.location.href = accountType === 'professional'
-            ? 'professional-dashboard.html'
-            : 'personal-dashboard.html';
-        } else {
-          // This case should ideally not happen if signup creates the user doc correctly
-          window.location.href = 'index.html';
-        }
-      } catch(err) {
-        // Display Firebase authentication errors directly on the page
-        errorEl.textContent = err.message;
-      }
-    });
-  </script>
 
   <div id="footer"></div>
   <script>
@@ -123,6 +28,5 @@
       .then(res => res.text())
       .then(html => { document.getElementById('footer').innerHTML = html; });
   </script>
-
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Sign Up – TradeStone</title>
+  <title>Choose Account Type – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 font-sans pb-16">
@@ -13,134 +13,14 @@
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
-    <h1 class="text-2xl font-bold mb-6 text-center">Create Account</h1>
-    <form id="signup-form" class="space-y-4">
-      <div>
-        <label class="block mb-1">Account Type</label>
-        <div class="flex gap-4">
-          <label class="inline-flex items-center">
-            <input type="radio" name="accountType" value="professional" required class="mr-2"/>
-            Professional
-          </label>
-          <label class="inline-flex items-center">
-            <input type="radio" name="accountType" value="personal" required class="mr-2"/>
-            Personal
-          </label>
-        </div>
-      </div>
-      <div>
-        <label for="email" class="block mb-1">Email</label>
-        <input id="email" name="email" type="email" required
-               class="w-full p-2 border rounded"/>
-      </div>
-      <div>
-        <label for="password" class="block mb-1">Password</label>
-        <input id="password" name="password" type="password" required
-               class="w-full p-2 border rounded"/>
-      </div>
-      <div>
-        <label for="confirmPassword" class="block mb-1">Confirm Password</label>
-        <input id="confirmPassword" name="confirmPassword" type="password" required
-               class="w-full p-2 border rounded"/>
-      </div>
-      <button type="submit"
-              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
-        Sign Up
-      </button>
-    </form>
-    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-6">
+    <h1 class="text-2xl font-bold">Sign Up</h1>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="professional-signup.html" class="px-6 py-3 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold">Professional Sign Up</a>
+      <a href="personal-signup.html" class="px-6 py-3 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold">Personal Sign Up</a>
+    </div>
+    <p class="text-sm">Already have an account? <a href="login.html" class="text-orange-600 font-medium">Log in</a></p>
   </main>
-
-  <div class="text-center mt-6">
-    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
-      <svg xmlns="http://www.w3.org/2000/svg"
-           class="h-8 w-8"
-           fill="none"
-           viewBox="0 0 24 24"
-           stroke="currentColor"
-           stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round"
-              d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z"/>
-        <path stroke-linecap="round" stroke-linejoin="round"
-              d="M9 22V12h6v10"/>
-      </svg>
-    </a>
-  </div>
-
-  <script type="module">
-    // Import necessary Firebase modules
-    import { onAuthStateChanged, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js";
-    import { doc, setDoc, getDoc } from "https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js";
-    // Import your centralized Firebase initialization
-    import { initFirebase } from './firebase-init.js';
-
-    // Initialize Firebase services using your centralized function
-    const { auth, db } = initFirebase();
-
-    // Check if a user is already logged in and redirect them
-    onAuthStateChanged(auth, async user => {
-      if (user) {
-        const snap = await getDoc(doc(db, 'users', user.uid));
-        if (snap.exists()) {
-          const { accountType } = snap.data();
-          window.location.href = accountType === 'professional'
-            ? 'professional-dashboard.html'
-            : 'personal-dashboard.html';
-        } else {
-          // Fallback if user exists in auth but not in Firestore 'users' collection
-          window.location.href = 'index.html';
-        }
-      }
-    });
-
-    const form = document.getElementById('signup-form');
-    const errorEl = document.getElementById('error-msg'); // Define error element
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Define email regex
-
-    // Handle form submission for signup
-    form.addEventListener('submit', async e => {
-      e.preventDefault();
-      errorEl.textContent = ''; // Clear any previous error messages
-
-      const email       = form.email.value;
-      // Validate email format using regex
-      if (!emailRegex.test(email)) {
-        errorEl.textContent = 'Please enter a valid email address.'; // Use errorEl for message
-        form.email.focus();
-        return;
-      }
-      const password    = form.password.value;
-      const confirm     = form.confirmPassword.value;
-      const accountType = form.accountType.value;
-
-      // Validate passwords match
-      if (password !== confirm) {
-        errorEl.textContent = 'Passwords do not match.';
-        return;
-      }
-
-      try {
-        // Create user with email and password
-        const { user } = await createUserWithEmailAndPassword(auth, email, password);
-        // Save user account type and default notification settings to Firestore
-        await setDoc(doc(db, 'users', user.uid), {
-          accountType,
-          notifications: { emailUpdates: true, smsUpdates: true } // Default notifications
-        });
-
-        // Redirect based on account type
-        if (accountType === 'professional') {
-          window.location.href = 'create-profile.html';
-        } else {
-          window.location.href = 'personal-dashboard.html';
-        }
-      } catch(err) {
-        // Display Firebase authentication errors directly on the page
-        errorEl.textContent = err.message;
-      }
-    });
-  </script>
 
   <div id="footer"></div>
   <script>
@@ -148,6 +28,5 @@
       .then(res => res.text())
       .then(html => { document.getElementById('footer').innerHTML = html; });
   </script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify `signup.html` to link to professional or personal signup
- simplify `login.html` to link to professional or personal login
- update header menu to point at the new choice pages
- document the new flow in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684853691a00832b908c9ca0127a6e3c