### PR TITLE
Add full trade catalog to profiles and search

### DIFF
--- a/browse-pros.html
+++ b/browse-pros.html
@@ -26,12 +26,48 @@
       <div>
         <p class="font-medium mb-2">Trade Type</p>
         <div class="space-y-1">
-          <label class="block"><input type="checkbox" value="Plumbing" class="trade-checkbox mr-2">Plumbing</label>
-          <label class="block"><input type="checkbox" value="Electrical" class="trade-checkbox mr-2">Electrical</label>
-          <label class="block"><input type="checkbox" value="Carpentry" class="trade-checkbox mr-2">Carpentry</label>
-          <label class="block"><input type="checkbox" value="Masonry" class="trade-checkbox mr-2">Masonry</label>
-          <label class="block"><input type="checkbox" value="Painting" class="trade-checkbox mr-2">Painting</label>
-          <label class="block"><input type="checkbox" value="General" class="trade-checkbox mr-2">General</label>
+          <label class="block"><input type="checkbox" value="Carpenter" class="trade-checkbox mr-2">Carpenter</label>
+          <label class="block"><input type="checkbox" value="Bricklayer / Mason" class="trade-checkbox mr-2">Bricklayer / Mason</label>
+          <label class="block"><input type="checkbox" value="Drywall Installer / Finisher" class="trade-checkbox mr-2">Drywall Installer / Finisher</label>
+          <label class="block"><input type="checkbox" value="Tiler" class="trade-checkbox mr-2">Tiler</label>
+          <label class="block"><input type="checkbox" value="Flooring Installer" class="trade-checkbox mr-2">Flooring Installer</label>
+          <label class="block"><input type="checkbox" value="Concrete Finisher" class="trade-checkbox mr-2">Concrete Finisher</label>
+          <label class="block"><input type="checkbox" value="Roofer" class="trade-checkbox mr-2">Roofer</label>
+          <label class="block"><input type="checkbox" value="Insulation Worker" class="trade-checkbox mr-2">Insulation Worker</label>
+          <label class="block"><input type="checkbox" value="Painter and Decorator" class="trade-checkbox mr-2">Painter and Decorator</label>
+          <label class="block"><input type="checkbox" value="Glazier (glass/window installation)" class="trade-checkbox mr-2">Glazier (glass/window installation)</label>
+          <label class="block"><input type="checkbox" value="Plasterer" class="trade-checkbox mr-2">Plasterer</label>
+          <label class="block"><input type="checkbox" value="Electrician" class="trade-checkbox mr-2">Electrician</label>
+          <label class="block"><input type="checkbox" value="Plumber" class="trade-checkbox mr-2">Plumber</label>
+          <label class="block"><input type="checkbox" value="HVAC Technician (Heating, Ventilation, and Air Conditioning)" class="trade-checkbox mr-2">HVAC Technician (Heating, Ventilation, and Air Conditioning)</label>
+          <label class="block"><input type="checkbox" value="Boilermaker" class="trade-checkbox mr-2">Boilermaker</label>
+          <label class="block"><input type="checkbox" value="Mechanical Installer" class="trade-checkbox mr-2">Mechanical Installer</label>
+          <label class="block"><input type="checkbox" value="Automation Technician" class="trade-checkbox mr-2">Automation Technician</label>
+          <label class="block"><input type="checkbox" value="Welder" class="trade-checkbox mr-2">Welder</label>
+          <label class="block"><input type="checkbox" value="Ironworker" class="trade-checkbox mr-2">Ironworker</label>
+          <label class="block"><input type="checkbox" value="Sheet Metal Worker" class="trade-checkbox mr-2">Sheet Metal Worker</label>
+          <label class="block"><input type="checkbox" value="Machinist" class="trade-checkbox mr-2">Machinist</label>
+          <label class="block"><input type="checkbox" value="Heavy Equipment Operator" class="trade-checkbox mr-2">Heavy Equipment Operator</label>
+          <label class="block"><input type="checkbox" value="Crane Operator" class="trade-checkbox mr-2">Crane Operator</label>
+          <label class="block"><input type="checkbox" value="Rigger" class="trade-checkbox mr-2">Rigger</label>
+          <label class="block"><input type="checkbox" value="Scaffolder" class="trade-checkbox mr-2">Scaffolder</label>
+          <label class="block"><input type="checkbox" value="Construction Manager" class="trade-checkbox mr-2">Construction Manager</label>
+          <label class="block"><input type="checkbox" value="Construction Inspector" class="trade-checkbox mr-2">Construction Inspector</label>
+          <label class="block"><input type="checkbox" value="Landscaper" class="trade-checkbox mr-2">Landscaper</label>
+          <label class="block"><input type="checkbox" value="Gardener" class="trade-checkbox mr-2">Gardener</label>
+          <label class="block"><input type="checkbox" value="Tree Surgeon / Arborist" class="trade-checkbox mr-2">Tree Surgeon / Arborist</label>
+          <label class="block"><input type="checkbox" value="Agricultural Technician" class="trade-checkbox mr-2">Agricultural Technician</label>
+          <label class="block"><input type="checkbox" value="Farmer" class="trade-checkbox mr-2">Farmer</label>
+          <label class="block"><input type="checkbox" value="Elevator Mechanic" class="trade-checkbox mr-2">Elevator Mechanic</label>
+          <label class="block"><input type="checkbox" value="Consultant" class="trade-checkbox mr-2">Consultant</label>
+          <label class="block"><input type="checkbox" value="Carpet Installer" class="trade-checkbox mr-2">Carpet Installer</label>
+          <label class="block"><input type="checkbox" value="Security System Installer" class="trade-checkbox mr-2">Security System Installer</label>
+          <label class="block"><input type="checkbox" value="Smart Home Technician" class="trade-checkbox mr-2">Smart Home Technician</label>
+          <label class="block"><input type="checkbox" value="Solar Panel Installer" class="trade-checkbox mr-2">Solar Panel Installer</label>
+          <label class="block"><input type="checkbox" value="Wind Turbine Technician" class="trade-checkbox mr-2">Wind Turbine Technician</label>
+          <label class="block"><input type="checkbox" value="Energy Efficiency Consultant" class="trade-checkbox mr-2">Energy Efficiency Consultant</label>
+          <label class="block"><input type="checkbox" value="Auto Mechanic" class="trade-checkbox mr-2">Auto Mechanic</label>
+          <label class="block"><input type="checkbox" value="Aircraft Mechanic" class="trade-checkbox mr-2">Aircraft Mechanic</label>
         </div>
       </div>
     </aside>

--- a/create-profile.html
+++ b/create-profile.html
@@ -37,12 +37,48 @@
       <div>
         <label for="tradeType" class="block mb-1">Trade Type</label>
         <select id="tradeType" name="tradeType" class="w-full p-2 border rounded" required>
-          <option value="Plumbing">Plumbing</option>
-          <option value="Electrical">Electrical</option>
-          <option value="Carpentry">Carpentry</option>
-          <option value="Masonry">Masonry</option>
-          <option value="Painting">Painting</option>
-          <option value="General">General</option>
+          <option value="Carpenter">Carpenter</option>
+          <option value="Bricklayer / Mason">Bricklayer / Mason</option>
+          <option value="Drywall Installer / Finisher">Drywall Installer / Finisher</option>
+          <option value="Tiler">Tiler</option>
+          <option value="Flooring Installer">Flooring Installer</option>
+          <option value="Concrete Finisher">Concrete Finisher</option>
+          <option value="Roofer">Roofer</option>
+          <option value="Insulation Worker">Insulation Worker</option>
+          <option value="Painter and Decorator">Painter and Decorator</option>
+          <option value="Glazier (glass/window installation)">Glazier (glass/window installation)</option>
+          <option value="Plasterer">Plasterer</option>
+          <option value="Electrician">Electrician</option>
+          <option value="Plumber">Plumber</option>
+          <option value="HVAC Technician (Heating, Ventilation, and Air Conditioning)">HVAC Technician (Heating, Ventilation, and Air Conditioning)</option>
+          <option value="Boilermaker">Boilermaker</option>
+          <option value="Mechanical Installer">Mechanical Installer</option>
+          <option value="Automation Technician">Automation Technician</option>
+          <option value="Welder">Welder</option>
+          <option value="Ironworker">Ironworker</option>
+          <option value="Sheet Metal Worker">Sheet Metal Worker</option>
+          <option value="Machinist">Machinist</option>
+          <option value="Heavy Equipment Operator">Heavy Equipment Operator</option>
+          <option value="Crane Operator">Crane Operator</option>
+          <option value="Rigger">Rigger</option>
+          <option value="Scaffolder">Scaffolder</option>
+          <option value="Construction Manager">Construction Manager</option>
+          <option value="Construction Inspector">Construction Inspector</option>
+          <option value="Landscaper">Landscaper</option>
+          <option value="Gardener">Gardener</option>
+          <option value="Tree Surgeon / Arborist">Tree Surgeon / Arborist</option>
+          <option value="Agricultural Technician">Agricultural Technician</option>
+          <option value="Farmer">Farmer</option>
+          <option value="Elevator Mechanic">Elevator Mechanic</option>
+          <option value="Consultant">Consultant</option>
+          <option value="Carpet Installer">Carpet Installer</option>
+          <option value="Security System Installer">Security System Installer</option>
+          <option value="Smart Home Technician">Smart Home Technician</option>
+          <option value="Solar Panel Installer">Solar Panel Installer</option>
+          <option value="Wind Turbine Technician">Wind Turbine Technician</option>
+          <option value="Energy Efficiency Consultant">Energy Efficiency Consultant</option>
+          <option value="Auto Mechanic">Auto Mechanic</option>
+          <option value="Aircraft Mechanic">Aircraft Mechanic</option>
         </select>
       </div>
       <div>

--- a/edit-profile.html
+++ b/edit-profile.html
@@ -39,6 +39,53 @@
         <input id="specializations" name="specializations" type="text" class="w-full p-2 border rounded" required />
       </div>
       <div>
+        <label for="tradeType" class="block mb-1">Trade Type</label>
+        <select id="tradeType" name="tradeType" class="w-full p-2 border rounded" required>
+          <option value="Carpenter">Carpenter</option>
+          <option value="Bricklayer / Mason">Bricklayer / Mason</option>
+          <option value="Drywall Installer / Finisher">Drywall Installer / Finisher</option>
+          <option value="Tiler">Tiler</option>
+          <option value="Flooring Installer">Flooring Installer</option>
+          <option value="Concrete Finisher">Concrete Finisher</option>
+          <option value="Roofer">Roofer</option>
+          <option value="Insulation Worker">Insulation Worker</option>
+          <option value="Painter and Decorator">Painter and Decorator</option>
+          <option value="Glazier (glass/window installation)">Glazier (glass/window installation)</option>
+          <option value="Plasterer">Plasterer</option>
+          <option value="Electrician">Electrician</option>
+          <option value="Plumber">Plumber</option>
+          <option value="HVAC Technician (Heating, Ventilation, and Air Conditioning)">HVAC Technician (Heating, Ventilation, and Air Conditioning)</option>
+          <option value="Boilermaker">Boilermaker</option>
+          <option value="Mechanical Installer">Mechanical Installer</option>
+          <option value="Automation Technician">Automation Technician</option>
+          <option value="Welder">Welder</option>
+          <option value="Ironworker">Ironworker</option>
+          <option value="Sheet Metal Worker">Sheet Metal Worker</option>
+          <option value="Machinist">Machinist</option>
+          <option value="Heavy Equipment Operator">Heavy Equipment Operator</option>
+          <option value="Crane Operator">Crane Operator</option>
+          <option value="Rigger">Rigger</option>
+          <option value="Scaffolder">Scaffolder</option>
+          <option value="Construction Manager">Construction Manager</option>
+          <option value="Construction Inspector">Construction Inspector</option>
+          <option value="Landscaper">Landscaper</option>
+          <option value="Gardener">Gardener</option>
+          <option value="Tree Surgeon / Arborist">Tree Surgeon / Arborist</option>
+          <option value="Agricultural Technician">Agricultural Technician</option>
+          <option value="Farmer">Farmer</option>
+          <option value="Elevator Mechanic">Elevator Mechanic</option>
+          <option value="Consultant">Consultant</option>
+          <option value="Carpet Installer">Carpet Installer</option>
+          <option value="Security System Installer">Security System Installer</option>
+          <option value="Smart Home Technician">Smart Home Technician</option>
+          <option value="Solar Panel Installer">Solar Panel Installer</option>
+          <option value="Wind Turbine Technician">Wind Turbine Technician</option>
+          <option value="Energy Efficiency Consultant">Energy Efficiency Consultant</option>
+          <option value="Auto Mechanic">Auto Mechanic</option>
+          <option value="Aircraft Mechanic">Aircraft Mechanic</option>
+        </select>
+      </div>
+      <div>
         <label for="location" class="block mb-1">Location</label>
         <input id="location" name="location" type="text" class="w-full p-2 border rounded" required />
       </div>
@@ -135,6 +182,7 @@
         form.description.value = data.description || '';
         form.teamMembers.value = data.teamMembers || '';
         form.specializations.value = data.specializations || '';
+        form.tradeType.value = data.tradeType || '';
         form.location.value = data.location || '';
         form.travelRadius.value = data.travelRadius || '';
 
@@ -156,6 +204,7 @@
           description: form.description.value,
           teamMembers: form.teamMembers.value,
           specializations: form.specializations.value,
+          tradeType: form.tradeType.value,
           location: form.location.value,
           travelRadius: form.travelRadius.value
         };


### PR DESCRIPTION
## Summary
- expand list of trade choices on the professional profile form
- add matching trade checkboxes on browse page
- allow trade type to be edited in profile settings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684856ff90cc832b9796e2f1873b8d7f