### PR TITLE
Add Firestore-backed blog feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,11 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 - Professionals can create a profile which is stored in Firestore and displayed on the browse page.
 - Error messages for login, signup, and account settings now appear directly on the page instead of using browser alert dialogs.
 
+### Blog
+
+- Visit **Blog** from the burger menu to read community posts.
+- When logged in, a form appears allowing you to publish a new post.
+- Click a post title to view it on its own page. There you can comment and hit the **Hammer** button to like the post.
+- Posting and commenting are restricted to authenticated users.
+
 All pages import `firebase-init.js` which centralizes Firebase initialization. Update that file with your credentials and the app will use them across every page.

--- a/blog-post.html
+++ b/blog-post.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Post – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h2 id="title" class="text-2xl font-bold mb-2"></h2>
+    <p id="content" class="mb-4"></p>
+    <button id="hammer-btn" class="bg-orange-500 text-white px-3 py-1 rounded mb-4">Hammer (<span id="hammer-count">0</span>)</button>
+    <div id="comments" class="space-y-2"></div>
+    <form id="comment-form" class="space-y-2 mt-4 hidden">
+      <textarea id="comment-text" required class="w-full p-2 border rounded" placeholder="Add a comment"></textarea>
+      <button type="submit" class="bg-orange-500 text-white px-3 py-1 rounded">Comment</button>
+    </form>
+  </main>
+
+  <script type="module">
+    import { initFirebase } from './firebase-init.js';
+    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+    import { getPost, getComments, addComment, toggleHammer } from './blog.js';
+
+    const { auth } = initFirebase();
+    const params = new URLSearchParams(window.location.search);
+    const postId = params.get('id');
+
+    const titleEl = document.getElementById('title');
+    const contentEl = document.getElementById('content');
+    const hammerBtn = document.getElementById('hammer-btn');
+    const hammerCount = document.getElementById('hammer-count');
+    const commentsEl = document.getElementById('comments');
+    const commentForm = document.getElementById('comment-form');
+
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        commentForm.classList.remove('hidden');
+        commentForm.addEventListener('submit', async e => {
+          e.preventDefault();
+          await addComment(postId, user.uid, document.getElementById('comment-text').value);
+          commentForm.reset();
+          loadComments();
+        });
+        hammerBtn.addEventListener('click', async () => {
+          await toggleHammer(postId, user.uid);
+          const post = await getPost(postId);
+          hammerCount.textContent = post.hammerCount || 0;
+        });
+      } else {
+        hammerBtn.disabled = true;
+      }
+    });
+
+    async function loadPost() {
+      const post = await getPost(postId);
+      if (!post) {
+        titleEl.textContent = 'Post not found';
+        return;
+      }
+      titleEl.textContent = post.title;
+      contentEl.textContent = post.content;
+      hammerCount.textContent = post.hammerCount || 0;
+    }
+
+    async function loadComments() {
+      const comments = await getComments(postId);
+      commentsEl.innerHTML = '';
+      if (!comments.length) {
+        commentsEl.innerHTML = '<p>No comments yet.</p>';
+        return;
+      }
+      for (const c of comments) {
+        const div = document.createElement('div');
+        div.className = 'border-b pb-2';
+        div.textContent = c.text;
+        commentsEl.appendChild(div);
+      }
+    }
+
+    loadPost();
+    loadComments();
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -7,24 +7,62 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 font-sans pb-16">
-
-  <!-- Header -->
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <!-- Main Content -->
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
+  <main class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
     <h2 class="text-2xl font-bold mb-4">Blog</h2>
-    <p>Coming soon... Share tips or ask for advice from other members.</p>
+    <form id="post-form" class="space-y-2 mb-6 hidden">
+      <input id="title" type="text" required placeholder="Title" class="w-full p-2 border rounded">
+      <textarea id="content" required placeholder="Share something..." class="w-full p-2 border rounded"></textarea>
+      <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded">Post</button>
+    </form>
+    <div id="posts-list" class="space-y-4"></div>
   </main>
 
-  <!-- Firebase Init -->
   <script type="module">
     import { initFirebase } from './firebase-init.js';
-    initFirebase();
+    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+    import { createPost, getPosts } from './blog.js';
+
+    const { auth } = initFirebase();
+    const form = document.getElementById('post-form');
+    const list = document.getElementById('posts-list');
+
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        form.classList.remove('hidden');
+        form.addEventListener('submit', async e => {
+          e.preventDefault();
+          await createPost(user.uid, form.title.value, form.content.value);
+          form.reset();
+          loadPosts();
+        });
+      }
+    });
+
+    async function loadPosts() {
+      list.innerHTML = '';
+      const posts = await getPosts();
+      if (!posts.length) {
+        list.innerHTML = '<p class="text-center">No posts yet.</p>';
+        return;
+      }
+      for (const post of posts) {
+        const div = document.createElement('div');
+        div.className = 'border-b pb-4';
+        div.innerHTML = `
+          <h3 class="text-xl font-bold"><a href="blog-post.html?id=${post.id}" class="text-orange-500 hover:underline">${post.title}</a></h3>
+          <p class="text-sm text-gray-700">${post.content.slice(0,100)}${post.content.length>100?'...':''}</p>
+          <p class="text-xs text-gray-500">Hammers: ${post.hammerCount || 0}</p>`;
+        list.appendChild(div);
+      }
+    }
+
+    loadPosts();
   </script>
   <div id="footer"></div>
   <script>
@@ -32,6 +70,5 @@
       .then(res => res.text())
       .then(html => { document.getElementById('footer').innerHTML = html; });
   </script>
-
 </body>
 </html>

--- a/blog.js
+++ b/blog.js
@@ -1,0 +1,59 @@
+import { initFirebase } from './firebase-init.js';
+import { collection, query, orderBy, addDoc, getDocs, getDoc, doc, serverTimestamp, setDoc, updateDoc, deleteDoc, increment } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+
+const { db } = initFirebase();
+
+export async function createPost(userId, title, content) {
+  const ref = await addDoc(collection(db, 'posts'), {
+    authorId: userId,
+    title,
+    content,
+    createdAt: serverTimestamp(),
+    hammerCount: 0
+  });
+  return ref.id;
+}
+
+export async function getPosts() {
+  const q = query(collection(db, 'posts'), orderBy('createdAt', 'desc'));
+  const snap = await getDocs(q);
+  return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+export async function getPost(id) {
+  const snap = await getDoc(doc(db, 'posts', id));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+export async function addComment(postId, userId, text) {
+  await addDoc(collection(db, 'posts', postId, 'comments'), {
+    authorId: userId,
+    text,
+    createdAt: serverTimestamp()
+  });
+}
+
+export async function getComments(postId) {
+  const q = query(collection(db, 'posts', postId, 'comments'), orderBy('createdAt'));
+  const snap = await getDocs(q);
+  return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+export async function toggleHammer(postId, userId) {
+  const hammerRef = doc(db, 'posts', postId, 'hammers', userId);
+  const hammerSnap = await getDoc(hammerRef);
+  if (hammerSnap.exists()) {
+    await deleteDoc(hammerRef);
+    await updateDoc(doc(db, 'posts', postId), { hammerCount: increment(-1) });
+    return false;
+  } else {
+    await setDoc(hammerRef, { createdAt: serverTimestamp() });
+    await updateDoc(doc(db, 'posts', postId), { hammerCount: increment(1) });
+    return true;
+  }
+}
+
+export async function hasHammered(postId, userId) {
+  const snap = await getDoc(doc(db, 'posts', postId, 'hammers', userId));
+  return snap.exists();
+}


### PR DESCRIPTION
## Summary
- implement `blog.js` for Firestore posts, comments and hammers
- expand `blog.html` with post list and new post form
- add `blog-post.html` page for viewing a single post
- document how to use the blog in `README`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68485a585414832ba4a732cae07c23f8