### PR TITLE
Configure Firebase via env or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 ## Setup
 
 1. Create a Firebase project and copy its configuration.
-2. Paste that configuration into `firebase-init.js` in the project root, replacing the sample values.
+2. Provide the credentials using environment variables or a config file:
+   - Set variables like `FIREBASE_API_KEY` and `FIREBASE_AUTH_DOMAIN` when bundling/serving the app.
+   - Or create `firebase-config.js` in the project root based on `firebase-config.example.js` and include it before `firebase-init.js` in your HTML.
 3. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.
 
 ## Usage
@@ -30,7 +32,7 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 - Click a post title to view it on its own page. There you can comment and hit the **Hammer** button to like the post.
 - Posting and commenting are restricted to authenticated users.
 
-All pages import `firebase-init.js` which centralizes Firebase initialization. Update that file with your credentials and the app will use them across every page.
+All pages import `firebase-init.js` which centralizes Firebase initialization. Supply credentials via environment variables or `firebase-config.js` and the app will use them across every page.
 
 ### Marketplace
 

--- a/firebase-config.example.js
+++ b/firebase-config.example.js
@@ -1,0 +1,17 @@
+/**
+ * Example configuration file for Firebase credentials.
+ *
+ * Copy this file to `firebase-config.js` and replace the placeholder values
+ * with your project's Firebase configuration. Include the file in your HTML
+ * before loading `firebase-init.js`.
+ */
+window.firebaseConfig = {
+  apiKey: '<API_KEY>',
+  authDomain: '<AUTH_DOMAIN>',
+  databaseURL: '<DATABASE_URL>',
+  projectId: '<PROJECT_ID>',
+  storageBucket: '<STORAGE_BUCKET>',
+  messagingSenderId: '<MESSAGING_SENDER_ID>',
+  appId: '<APP_ID>',
+  measurementId: '<MEASUREMENT_ID>'
+};

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -3,17 +3,26 @@ import { getAuth } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
 import { getStorage } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
 
-// Replace these credentials with your Firebase project configuration
-const firebaseConfig = {
-  apiKey: 'AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo',
-  authDomain: 'tradestone-efb30.firebaseapp.com',
-  databaseURL: 'https://tradestone-efb30-default-rtdb.firebaseio.com',
-  projectId: 'tradestone-efb30',
-  storageBucket: 'tradestone-efb30.appspot.com',
-  messagingSenderId: '761717818779',
-  appId: '1:761717818779:web:05287865a076dbfed68d3e',
-  measurementId: 'G-TM9DK5H25J'
-};
+/**
+ * Build the Firebase configuration using environment variables when available
+ * or values exposed on `window.firebaseConfig` via a separate config file.
+ */
+function buildConfig() {
+  const env = (typeof process !== 'undefined' && process.env) ? process.env : {};
+  const win = (typeof window !== 'undefined' ? window : {});
+  const cfg = win.firebaseConfig || {};
+
+  return {
+    apiKey: env.FIREBASE_API_KEY || cfg.apiKey || '<API_KEY>',
+    authDomain: env.FIREBASE_AUTH_DOMAIN || cfg.authDomain || '<AUTH_DOMAIN>',
+    databaseURL: env.FIREBASE_DATABASE_URL || cfg.databaseURL || '<DATABASE_URL>',
+    projectId: env.FIREBASE_PROJECT_ID || cfg.projectId || '<PROJECT_ID>',
+    storageBucket: env.FIREBASE_STORAGE_BUCKET || cfg.storageBucket || '<STORAGE_BUCKET>',
+    messagingSenderId: env.FIREBASE_MESSAGING_SENDER_ID || cfg.messagingSenderId || '<MESSAGING_SENDER_ID>',
+    appId: env.FIREBASE_APP_ID || cfg.appId || '<APP_ID>',
+    measurementId: env.FIREBASE_MEASUREMENT_ID || cfg.measurementId || '<MEASUREMENT_ID>'
+  };
+}
 
 let services;
 
@@ -23,7 +32,7 @@ let services;
  */
 export function initFirebase() {
   if (!services) {
-    const app = initializeApp(firebaseConfig);
+    const app = initializeApp(buildConfig());
     services = {
       app,
       auth: getAuth(app),


### PR DESCRIPTION
## Summary
- allow `firebase-init.js` to read credentials from environment variables or from a `firebase-config.js` file
- document the new configuration options in README
- add `firebase-config.example.js` as a template for custom credentials

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68488de63df0832ba14148dc0770f28e