### PR TITLE
Add .gitignore for common artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Dependency directories
+node_modules/
+
+# Build artifacts
+build/
+dist/
+out/
+
+# Temporary files
+.tmp/
+tmp/
+.temp/
+uploads/
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
## Summary
- add .gitignore to ignore editor folders, build outputs and temporary files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68488ded509c832ba5839522bc19226c