### PR TITLE
Add accessible labels to header

### DIFF
--- a/header.html
+++ b/header.html
@@ -12,12 +12,14 @@
     <!-- Burger menu button visible on all screen sizes -->
     <!-- Event handler registered in loadHeader.js -->
     <button id="burger-btn" class="focus:outline-none">
+      <span class="sr-only">Menu</span>
       <svg class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
       </svg>
     </button>
     <!-- Profile icon -->
     <a href="personal-dashboard.html">
+      <span class="sr-only">Dashboard</span>
       <svg class="h-6 w-6 text-gray-700" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
       </svg>


### PR DESCRIPTION
## Summary
- expose a text label for the burger menu button
- provide hidden dashboard label for the profile icon

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`
- `make test` *(fails: no rule for target)*

------
https://chatgpt.com/codex/tasks/task_e_68488dee60d0832b9d61746c254ee23b