### PR TITLE
Add Firestore-based messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ All pages import `firebase-init.js` which centralizes Firebase initialization. U
   - `images` – array of download URLs (optional)
   - `postedBy` – UID of the user who created the listing
   - `createdAt` – Firestore timestamp
+
+### Messaging
+
+- Visit **Messages** from the burger menu to chat with other users.
+- Conversations appear on the left. Select one to view and send messages in real time.

--- a/messages.html
+++ b/messages.html
@@ -16,17 +16,22 @@
   </script>
 
   <!-- Main Content -->
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
-    <h2 class="text-2xl font-bold mb-4">Messages</h2>
-    <p>Coming soon...</p>
+  <main class="max-w-4xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h2 class="text-2xl font-bold mb-4 text-center">Messages</h2>
+    <div class="flex">
+      <aside id="conversation-list" class="w-1/3 border-r pr-4"></aside>
+      <section class="flex-1 pl-4">
+        <div id="messages" class="h-64 overflow-y-auto border rounded mb-2 p-2"></div>
+        <form id="message-form" class="flex space-x-2">
+          <input id="message-input" type="text" class="flex-1 border rounded px-2 py-1" placeholder="Type a message" />
+          <button type="submit" class="bg-orange-500 text-white px-4 rounded">Send</button>
+        </form>
+      </section>
+    </div>
   </main>
 
 
-  <!-- Firebase Init -->
-  <script type="module">
-    import { initFirebase } from './firebase-init.js';
-    initFirebase();
-  </script>
+  <script type="module" src="./messages.js"></script>
   <div id="footer"></div>
   <script>
     fetch('footer.html')

--- a/messages.js
+++ b/messages.js
@@ -1,0 +1,80 @@
+import { initFirebase } from './firebase-init.js';
+import {
+  onAuthStateChanged
+} from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  addDoc,
+  onSnapshot,
+  serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+
+const { auth, db } = initFirebase();
+
+const convListEl = document.getElementById('conversation-list');
+const messagesEl = document.getElementById('messages');
+const form = document.getElementById('message-form');
+const input = document.getElementById('message-input');
+
+let currentConvId = null;
+let unsubMessages = null;
+
+onAuthStateChanged(auth, user => {
+  if (!user) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  loadConversations(user.uid);
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    if (!currentConvId || !input.value.trim()) return;
+    await addDoc(collection(db, 'conversations', currentConvId, 'messages'), {
+      sender: user.uid,
+      text: input.value.trim(),
+      createdAt: serverTimestamp()
+    });
+    input.value = '';
+  });
+});
+
+function loadConversations(uid) {
+  const q = query(collection(db, 'conversations'), where('participants', 'array-contains', uid));
+  onSnapshot(q, snap => {
+    convListEl.innerHTML = '';
+    if (snap.empty) {
+      convListEl.innerHTML = '<p class="text-gray-700">No conversations.</p>';
+      return;
+    }
+    snap.forEach(doc => {
+      const data = doc.data();
+      const btn = document.createElement('button');
+      btn.className = 'block w-full text-left px-2 py-1 hover:bg-gray-100';
+      btn.textContent = data.title || doc.id;
+      btn.addEventListener('click', () => selectConversation(doc.id));
+      convListEl.appendChild(btn);
+    });
+  });
+}
+
+function selectConversation(id) {
+  currentConvId = id;
+  messagesEl.innerHTML = '';
+  if (unsubMessages) unsubMessages();
+  const q = query(collection(db, 'conversations', id, 'messages'), orderBy('createdAt'));
+  unsubMessages = onSnapshot(q, snap => {
+    messagesEl.innerHTML = '';
+    snap.forEach(doc => {
+      const m = doc.data();
+      const div = document.createElement('div');
+      div.className = m.sender === auth.currentUser.uid ? 'text-right' : 'text-left';
+      div.innerHTML = `<span class="inline-block bg-gray-100 rounded px-2 py-1 my-1">${m.text}</span>`;
+      messagesEl.appendChild(div);
+    });
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  });
+}


### PR DESCRIPTION
## Summary
- implement real-time conversations using Firestore
- create `messages.js` to load and send messages
- build UI in `messages.html`
- document the feature in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68488deedf54832b950b610c555efcbc