### PR TITLE
Make filters sidebar scrollable

### DIFF
--- a/browse-pros.html
+++ b/browse-pros.html
@@ -26,7 +26,7 @@
   </script>
 
   <div class="max-w-7xl mx-auto mt-4 p-4 flex flex-col md:flex-row gap-8">
-    <aside class="w-full md:w-64 space-y-4 bg-white rounded-lg shadow p-4 self-start">
+    <aside class="w-full md:w-64 space-y-4 bg-white rounded-lg shadow p-4 self-start md:max-h-screen md:overflow-y-auto">
       <div>
         <label for="search" class="block mb-1 font-medium">Search by Name</label>
         <input id="search" type="text" class="w-full p-2 border rounded" placeholder="e.g., John Smith" />


### PR DESCRIPTION
## Summary
- keep the contractor filter sidebar from expanding the page by making it scrollable

## Testing
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_68489402edec832bb491741903d51ed3