### PR TITLE
Add utility for demo accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,30 @@ All pages import `firebase-init.js` which centralizes Firebase initialization. S
 
 - Visit **Messages** from the burger menu to chat with other users.
 - Conversations appear on the left. Select one to view and send messages in real time.
+
+### Test Accounts
+
+A small utility script is included to spin up demo users so you can showcase the
+site without cluttering your real database. The script uses the Firebase Admin
+SDK and requires a service account JSON key.
+
+1. Install dependencies using `npm install` (requires internet access).
+2. Export the path to your service account key:
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/serviceAccountKey.json
+   ```
+3. Create the demo users:
+   ```bash
+   node scripts/manage-test-users.js create
+   ```
+   Two accounts will be created:
+   - `demo-personal@example.com` (password `demopass`)
+   - `demo-professional@example.com` (password `demopass`)
+4. When finished testing, remove them with:
+   ```bash
+   node scripts/manage-test-users.js delete
+   ```
+
+The script adds the appropriate documents to the `users` collection so the demo
+accounts behave like normal ones and can post in the marketplace or create
+profiles. Deleting removes the auth user and related Firestore document.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tradestone",
+  "version": "1.0.0",
+  "description": "Utility scripts for TradeStone",
+  "type": "module",
+  "dependencies": {
+    "firebase-admin": "^11.10.1"
+  }
+}

--- a/scripts/manage-test-users.js
+++ b/scripts/manage-test-users.js
@@ -1,0 +1,61 @@
+const admin = require('firebase-admin');
+
+const action = process.argv[2];
+if (!action || !['create', 'delete'].includes(action)) {
+  console.log('Usage: node scripts/manage-test-users.js <create|delete>');
+  process.exit(1);
+}
+
+// Initialize using the default credentials or service account specified via
+// GOOGLE_APPLICATION_CREDENTIALS.
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+});
+
+const auth = admin.auth();
+const db = admin.firestore();
+
+const testUsers = [
+  { email: 'demo-personal@example.com', password: 'demopass', accountType: 'personal' },
+  { email: 'demo-professional@example.com', password: 'demopass', accountType: 'professional' },
+];
+
+async function createUsers() {
+  for (const user of testUsers) {
+    try {
+      const { uid } = await auth.createUser({ email: user.email, password: user.password });
+      await db.collection('users').doc(uid).set({
+        accountType: user.accountType,
+        notifications: { emailUpdates: true, smsUpdates: true },
+      });
+      console.log(`Created ${user.email}`);
+    } catch (err) {
+      console.error(`Failed to create ${user.email}: ${err.message}`);
+    }
+  }
+}
+
+async function deleteUsers() {
+  for (const user of testUsers) {
+    try {
+      const existing = await auth.getUserByEmail(user.email);
+      await db.collection('users').doc(existing.uid).delete();
+      await auth.deleteUser(existing.uid);
+      console.log(`Deleted ${user.email}`);
+    } catch (err) {
+      if (err.code === 'auth/user-not-found') {
+        console.log(`${user.email} not found, skipping.`);
+      } else {
+        console.error(`Failed to delete ${user.email}: ${err.message}`);
+      }
+    }
+  }
+}
+
+(async () => {
+  if (action === 'create') {
+    await createUsers();
+  } else {
+    await deleteUsers();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a script to manage Firebase demo users
- document how to create and delete the demo accounts
- define firebase-admin dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858085a6f20832b8e6d130f4caa1e78