### PR TITLE
Add contracts listing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ All pages import `firebase-init.js` which centralizes Firebase initialization. S
   - `postedBy` – UID of the user who created the listing
   - `createdAt` – Firestore timestamp
 
+### Contracts
+
+- Browse contract opportunities on `contracts.html`. Use the sidebar filters to search by text or location.
+- Professional accounts can create new listings from `post-contract.html`.
+- Applications are stored in the `applications` subcollection of each contract document.
+
 ### Messaging
 
 - Visit **Messages** from the burger menu to chat with other users.

--- a/contracts.html
+++ b/contracts.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contracts – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <div class="max-w-7xl mx-auto mt-4 p-4 flex flex-col md:flex-row gap-8">
+    <aside class="w-full md:w-64 space-y-4 bg-white rounded-lg shadow p-4 self-start">
+      <div>
+        <label for="search" class="block mb-1 font-medium">Search</label>
+        <input id="search" type="text" class="w-full p-2 border rounded" placeholder="Search contracts" />
+      </div>
+      <div>
+        <label for="location-filter" class="block mb-1 font-medium">Location</label>
+        <input id="location-filter" type="text" class="w-full p-2 border rounded" placeholder="e.g. London" />
+      </div>
+      <button id="apply-filters" class="bg-orange-500 text-white px-4 py-2 rounded w-full">Apply</button>
+    </aside>
+
+    <main class="flex-1 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" id="contract-list"></main>
+  </div>
+
+  <script type="module" src="./contracts.js"></script>
+  <script type="module">
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>

--- a/contracts.js
+++ b/contracts.js
@@ -1,0 +1,94 @@
+import { initFirebase } from './firebase-init.js';
+import { collection, getDocs, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+
+const { db, auth } = initFirebase();
+let allContracts = [];
+const list = document.getElementById('contract-list');
+
+function createCard(contract) {
+  const card = document.createElement('div');
+  card.className = 'bg-white rounded-lg shadow p-4 flex flex-col space-y-2';
+
+  const title = document.createElement('h2');
+  title.className = 'text-lg font-bold';
+  title.textContent = contract.title;
+  card.appendChild(title);
+
+  const desc = document.createElement('p');
+  desc.className = 'text-sm text-gray-700';
+  desc.textContent = contract.description;
+  card.appendChild(desc);
+
+  if (contract.location) {
+    const loc = document.createElement('p');
+    loc.className = 'text-sm text-gray-700';
+    loc.textContent = contract.location;
+    card.appendChild(loc);
+  }
+
+  if (contract.budget) {
+    const bud = document.createElement('p');
+    bud.className = 'text-sm text-gray-700';
+    bud.textContent = `Budget: £${Number(contract.budget).toFixed(2)}`;
+    card.appendChild(bud);
+  }
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Apply';
+  btn.className = 'mt-auto bg-orange-500 text-white px-4 py-1 rounded';
+  btn.addEventListener('click', () => applyForContract(contract.id));
+  card.appendChild(btn);
+
+  return card;
+}
+
+async function applyForContract(id) {
+  const user = auth.currentUser;
+  if (!user) {
+    window.location.href = 'login.html';
+    return;
+  }
+  try {
+    await addDoc(collection(db, 'contracts', id, 'applications'), {
+      applicant: user.uid,
+      createdAt: serverTimestamp()
+    });
+    alert('Application submitted');
+  } catch (err) {
+    alert(err.message);
+  }
+}
+
+function filterAndRender() {
+  const search = document.getElementById('search').value.toLowerCase();
+  const location = document.getElementById('location-filter').value.trim().toLowerCase();
+
+  const filtered = allContracts.filter(c => {
+    const matchText = !search || (c.title && c.title.toLowerCase().includes(search)) || (c.description && c.description.toLowerCase().includes(search));
+    const matchLocation = !location || (c.location && c.location.toLowerCase().includes(location));
+    return matchText && matchLocation;
+  });
+
+  list.innerHTML = '';
+  if (filtered.length === 0) {
+    list.innerHTML = '<p class="text-gray-700 text-center col-span-full">No contracts found.</p>';
+  } else {
+    filtered.forEach(c => list.appendChild(createCard(c)));
+  }
+}
+
+async function loadContracts() {
+  try {
+    const snap = await getDocs(collection(db, 'contracts'));
+    allContracts = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    filterAndRender();
+  } catch (err) {
+    console.error('Error loading contracts:', err);
+    list.innerHTML = '<p class="text-red-500 text-center col-span-full">Could not load contracts.</p>';
+  }
+}
+
+document.getElementById('apply-filters').addEventListener('click', filterAndRender);
+loadContracts();
+

--- a/header.html
+++ b/header.html
@@ -30,6 +30,8 @@
   <div id="burger-menu" class="hidden fixed inset-y-0 right-0 w-64 transform translate-x-full transition-transform bg-white border-l border-gray-200 p-4 space-y-2">
     <a href="browse-pros.html" class="block px-4 py-2 hover:bg-gray-100">Browse</a>
     <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-100">Marketplace</a>
+    <a href="contracts.html" class="block px-4 py-2 hover:bg-gray-100">Contracts</a>
+    <a href="post-contract.html" class="block px-4 py-2 hover:bg-gray-100">Post Contract</a>
     <a href="post.html" class="block px-4 py-2 hover:bg-gray-100">Post Item</a>
     <a href="blog.html" class="block px-4 py-2 hover:bg-gray-100">Blog</a>
     <a href="messages.html" class="block px-4 py-2 hover:bg-gray-100">Messages</a>

--- a/index.html
+++ b/index.html
@@ -73,16 +73,18 @@ Buy and sell excess materials, win more work, and connect with the right clients
         </div>
       </a>
       <!-- Card 3 -->
+      <a href="contracts.html" class="block">
       <div class="bg-white rounded-xl shadow p-4 text-center">
         <svg class="h-10 w-10 mx-auto mb-2 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round"
-                d="M7 7h10M7 11h6m-6 4h10M5 3h14a2  
-                   2 0 012 2v14a2 2 0 01-2 2H5a2  
+                d="M7 7h10M7 11h6m-6 4h10M5 3h14a2
+                   2 0 012 2v14a2 2 0 01-2 2H5a2
                    2 0 01-2-2V5a2 2 0 012-2z"/>
         </svg>
         <h3 class="font-semibold mb-1">Apply for Contracts</h3>
         <p class="text-gray-600 text-sm">Bid on government and private jobs.</p>
       </div>
+      </a>
     </div>
   </section>
 

--- a/post-contract.html
+++ b/post-contract.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Post Contract – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h2 class="text-2xl font-bold mb-4 text-center">Post Contract</h2>
+    <form id="contract-form" class="space-y-4">
+      <div>
+        <label for="title" class="block mb-1">Title</label>
+        <input id="title" name="title" type="text" required class="w-full p-2 border rounded" />
+      </div>
+      <div>
+        <label for="description" class="block mb-1">Description</label>
+        <textarea id="description" name="description" rows="3" class="w-full p-2 border rounded" required></textarea>
+      </div>
+      <div>
+        <label for="budget" class="block mb-1">Budget (£)</label>
+        <input id="budget" name="budget" type="number" step="0.01" min="0" class="w-full p-2 border rounded" />
+      </div>
+      <div>
+        <label for="location" class="block mb-1">Location</label>
+        <input id="location" name="location" type="text" class="w-full p-2 border rounded" required />
+      </div>
+      <div id="error-msg" class="text-red-500 text-center"></div>
+      <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Post Contract</button>
+    </form>
+  </main>
+
+  <script type="module">
+    import { initFirebase } from './firebase-init.js';
+    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+    import { addDoc, collection, serverTimestamp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+
+    const { auth, db } = initFirebase();
+    const form = document.getElementById('contract-form');
+    const errorEl = document.getElementById('error-msg');
+
+    onAuthStateChanged(auth, async user => {
+      if (!user) {
+        window.location.href = 'login.html';
+        return;
+      }
+
+      const userSnap = await import('https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js').then(m => m.getDoc(m.doc(db, 'users', user.uid)));
+      if (userSnap.exists() && userSnap.data().accountType !== 'professional') {
+        errorEl.textContent = 'Only professional accounts can post contracts.';
+        form.querySelector('button').disabled = true;
+        return;
+      }
+
+      form.addEventListener('submit', async e => {
+        e.preventDefault();
+        errorEl.textContent = '';
+
+        const data = {
+          title: form.title.value.trim(),
+          description: form.description.value.trim(),
+          budget: parseFloat(form.budget.value) || null,
+          location: form.location.value.trim(),
+          postedBy: user.uid,
+          createdAt: serverTimestamp()
+        };
+
+        if (!data.title || !data.description || !data.location) {
+          errorEl.textContent = 'Please fill in all required fields.';
+          return;
+        }
+
+        await addDoc(collection(db, 'contracts'), data);
+        form.reset();
+        alert('Contract posted!');
+      });
+    });
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- link 'Apply for Contracts' card on home page
- add navigation links for browsing and posting contracts
- implement contracts browser and posting pages backed by Firestore
- document new contract functionality

## Testing
- `npm test` *(fails: Missing script & network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68580b12872c832b955c5dd1a975f530