### PR TITLE
Add advanced contract filters

### DIFF
--- a/contracts.html
+++ b/contracts.html
@@ -13,8 +13,9 @@
     loadHeader();
   </script>
 
+  <button id="toggle-filters" class="md:hidden mx-4 mt-4 bg-orange-500 text-white px-4 py-2 rounded">Filters</button>
   <div class="max-w-7xl mx-auto mt-4 p-4 flex flex-col md:flex-row gap-8">
-    <aside class="w-full md:w-64 space-y-4 bg-white rounded-lg shadow p-4 self-start">
+    <aside id="filter-sidebar" class="w-full md:w-64 space-y-4 bg-white rounded-lg shadow p-4 self-start hidden md:block md:max-h-screen md:overflow-y-auto">
       <div>
         <label for="search" class="block mb-1 font-medium">Search</label>
         <input id="search" type="text" class="w-full p-2 border rounded" placeholder="Search contracts" />
@@ -22,6 +23,36 @@
       <div>
         <label for="location-filter" class="block mb-1 font-medium">Location</label>
         <input id="location-filter" type="text" class="w-full p-2 border rounded" placeholder="e.g. London" />
+      </div>
+      <div>
+        <label for="contract-type" class="block mb-1 font-medium">Contract Type</label>
+        <select id="contract-type" class="w-full p-2 border rounded">
+          <option value="">Any</option>
+          <option value="private">Private</option>
+          <option value="government">Government</option>
+        </select>
+      </div>
+      <div>
+        <p class="font-medium mb-2">Trade Category</p>
+        <div class="space-y-1" id="trade-list"></div>
+      </div>
+      <div>
+        <p class="font-medium mb-2">Budget (£)</p>
+        <div class="flex space-x-2">
+          <input id="budget-min" type="number" class="w-1/2 p-2 border rounded" placeholder="Min" />
+          <input id="budget-max" type="number" class="w-1/2 p-2 border rounded" placeholder="Max" />
+        </div>
+      </div>
+      <div>
+        <p class="font-medium mb-2">Date Range</p>
+        <input id="start-date-from" type="date" class="w-full p-2 border rounded mb-1" />
+        <input id="start-date-to" type="date" class="w-full p-2 border rounded" />
+      </div>
+      <div>
+        <label class="block"><input id="verified-only" type="checkbox" class="mr-2" />Verified Only</label>
+      </div>
+      <div>
+        <label class="block"><input id="qualify-only" type="checkbox" class="mr-2" />Only Show Contracts I Qualify For</label>
       </div>
       <button id="apply-filters" class="bg-orange-500 text-white px-4 py-2 rounded w-full">Apply</button>
     </aside>
@@ -32,7 +63,19 @@
   <script type="module" src="./contracts.js"></script>
   <script type="module">
     import { initFirebase } from './firebase-init.js';
+    import { tradeTypes } from './trade-types.js';
     initFirebase();
+    const container = document.getElementById('trade-list');
+    tradeTypes.forEach(t => {
+      const label = document.createElement('label');
+      label.className = 'block';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.value = t;
+      cb.className = 'trade-checkbox mr-2';
+      label.append(cb, document.createTextNode(t));
+      container.appendChild(label);
+    });
   </script>
   <div id="footer"></div>
   <script>

--- a/contracts.js
+++ b/contracts.js
@@ -1,11 +1,24 @@
 import { initFirebase } from './firebase-init.js';
-import { collection, getDocs, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+import { collection, getDocs, addDoc, serverTimestamp, query, where, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
 
 const { db, auth } = initFirebase();
+let userTrade = null;
 let allContracts = [];
 const list = document.getElementById('contract-list');
 
+onAuthStateChanged(auth, async user => {
+  if (user) {
+    try {
+      const snap = await getDoc(doc(db, 'profiles', user.uid));
+      if (snap.exists()) {
+        userTrade = snap.data().tradeType || null;
+      }
+    } catch (err) {
+      console.error('Failed to load user profile', err);
+    }
+  }
+});
 function createCard(contract) {
   const card = document.createElement('div');
   card.className = 'bg-white rounded-lg shadow p-4 flex flex-col space-y-2';
@@ -60,14 +73,53 @@ async function applyForContract(id) {
   }
 }
 
-function filterAndRender() {
+async function filterAndRender() {
   const search = document.getElementById('search').value.toLowerCase();
   const location = document.getElementById('location-filter').value.trim().toLowerCase();
+  const contractType = document.getElementById('contract-type').value;
+  const selectedTrades = Array.from(document.querySelectorAll('.trade-checkbox:checked')).map(cb => cb.value);
+  const minBudget = parseFloat(document.getElementById('budget-min').value);
+  const maxBudget = parseFloat(document.getElementById('budget-max').value);
+  const startAfter = document.getElementById('start-date-from').value;
+  const endBefore = document.getElementById('start-date-to').value;
+  const verifiedOnly = document.getElementById('verified-only').checked;
+  const qualifyOnly = document.getElementById('qualify-only').checked;
+
+  let q = collection(db, 'contracts');
+  const conditions = [];
+  if (contractType) conditions.push(where('type', '==', contractType));
+  if (selectedTrades.length) conditions.push(where('trade', 'array-contains-any', selectedTrades));
+  if (!isNaN(minBudget)) conditions.push(where('budget', '>=', minBudget));
+  if (!isNaN(maxBudget)) conditions.push(where('budget', '<=', maxBudget));
+  if (startAfter) conditions.push(where('startDate', '>=', startAfter));
+  if (endBefore) conditions.push(where('endDate', '<=', endBefore));
+  if (verifiedOnly) conditions.push(where('verified', '==', true));
+  if (conditions.length) q = query(q, ...conditions);
+
+  try {
+    const snap = await getDocs(q);
+    allContracts = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  } catch (err) {
+    console.error('Error loading contracts:', err);
+    list.innerHTML = '<p class="text-red-500 text-center col-span-full">Could not load contracts.</p>';
+    return;
+  }
 
   const filtered = allContracts.filter(c => {
     const matchText = !search || (c.title && c.title.toLowerCase().includes(search)) || (c.description && c.description.toLowerCase().includes(search));
     const matchLocation = !location || (c.location && c.location.toLowerCase().includes(location));
-    return matchText && matchLocation;
+    let matchQualify = true;
+    if (qualifyOnly && userTrade) {
+      const tradeVal = c.trade || c.tradeType || c.tradeCategory;
+      if (Array.isArray(tradeVal)) {
+        matchQualify = tradeVal.map(t => t.toLowerCase()).includes(userTrade.toLowerCase());
+      } else if (typeof tradeVal === 'string') {
+        matchQualify = tradeVal.toLowerCase() === userTrade.toLowerCase();
+      } else {
+        matchQualify = false;
+      }
+    }
+    return matchText && matchLocation && matchQualify;
   });
 
   list.innerHTML = '';
@@ -79,16 +131,15 @@ function filterAndRender() {
 }
 
 async function loadContracts() {
-  try {
-    const snap = await getDocs(collection(db, 'contracts'));
-    allContracts = snap.docs.map(d => ({ id: d.id, ...d.data() }));
-    filterAndRender();
-  } catch (err) {
-    console.error('Error loading contracts:', err);
-    list.innerHTML = '<p class="text-red-500 text-center col-span-full">Could not load contracts.</p>';
-  }
+  filterAndRender();
 }
 
 document.getElementById('apply-filters').addEventListener('click', filterAndRender);
+const toggle = document.getElementById('toggle-filters');
+if (toggle) {
+  toggle.addEventListener('click', () => {
+    document.getElementById('filter-sidebar').classList.toggle('hidden');
+  });
+}
 loadContracts();
 


### PR DESCRIPTION
## Summary
- add collapsible filter sidebar to contracts page
- populate trade categories from `trade-types.js`
- implement advanced filtering logic querying Firestore

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68581255c0b8832ba4766991561be1dd