### PR TITLE
Add contract detail page

### DIFF
--- a/contract-detail.html
+++ b/contract-detail.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contract Detail – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main id="contract-content" class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h2 id="contract-title" class="text-2xl font-bold mb-2"></h2>
+    <p id="contract-description" class="mb-4"></p>
+    <p id="contract-budget" class="text-gray-700"></p>
+    <p id="contract-location" class="text-gray-700 mb-4"></p>
+
+    <div id="contract-documents" class="mb-6"></div>
+    <div id="contract-questions" class="mb-6"></div>
+
+    <form id="bid-form" class="space-y-2 hidden">
+      <input id="bid-amount" type="number" step="0.01" min="0" required class="w-full p-2 border rounded" placeholder="Bid Amount (£)">
+      <textarea id="bid-message" class="w-full p-2 border rounded" placeholder="Message"></textarea>
+      <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded">Submit Bid</button>
+    </form>
+    <button id="watch-btn" class="mt-4 bg-orange-500 text-white px-4 py-2 rounded hidden">Add to Watchlist</button>
+  </main>
+
+  <script type="module" src="./contract-detail.js"></script>
+  <script type="module">
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html').then(res => res.text()).then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>

--- a/contracts.js
+++ b/contracts.js
@@ -34,6 +34,12 @@ function createCard(contract) {
     card.appendChild(bud);
   }
 
+  const view = document.createElement('a');
+  view.href = `contract-detail.html?id=${contract.id}`;
+  view.textContent = 'View Details';
+  view.className = 'text-orange-500 hover:underline';
+  card.appendChild(view);
+
   const btn = document.createElement('button');
   btn.textContent = 'Apply';
   btn.className = 'mt-auto bg-orange-500 text-white px-4 py-1 rounded';


### PR DESCRIPTION
## Summary
- add page to show individual contract details
- enable Pro users to submit bids and watchlist contracts
- display documents and questions on the detail page
- link contracts to the new detail view

## Testing
- `npm test` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6858125c4bdc832b91e856ec4658a3da