### PR TITLE
Add firebase-config.js to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+firebase-config.js


### PR DESCRIPTION
## Summary
- avoid committing local Firebase credentials by ignoring `firebase-config.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685818cd0ef4832baae759a08a64112c