### PR TITLE
Use inline status messages instead of alerts

### DIFF
--- a/contract-detail.html
+++ b/contract-detail.html
@@ -28,6 +28,7 @@
       <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded">Submit Bid</button>
     </form>
     <button id="watch-btn" class="mt-4 bg-orange-500 text-white px-4 py-2 rounded hidden">Add to Watchlist</button>
+    <div id="status-msg" class="text-red-500 mt-2 text-center"></div>
   </main>
 
   <script type="module" src="./contract-detail.js"></script>

--- a/contract-detail.js
+++ b/contract-detail.js
@@ -22,6 +22,7 @@ const docsEl = document.getElementById('contract-documents');
 const questionsEl = document.getElementById('contract-questions');
 const bidForm = document.getElementById('bid-form');
 const watchBtn = document.getElementById('watch-btn');
+const statusEl = document.getElementById('status-msg');
 
 let currentUser = null;
 let isPro = false;
@@ -102,7 +103,7 @@ async function submitBid(e) {
     createdAt: serverTimestamp()
   });
   bidForm.reset();
-  alert('Bid submitted');
+  statusEl.textContent = 'Bid submitted';
 }
 
 async function addToWatchlist() {
@@ -112,6 +113,7 @@ async function addToWatchlist() {
   });
   watchBtn.textContent = 'Added to Watchlist';
   watchBtn.disabled = true;
+  statusEl.textContent = 'Added to Watchlist';
 }
 
 loadContract();

--- a/contracts.html
+++ b/contracts.html
@@ -58,6 +58,7 @@
     </aside>
 
     <main class="flex-1 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" id="contract-list"></main>
+    <div id="status-msg" class="text-red-500 mt-2 text-center"></div>
   </div>
 
   <script type="module" src="./contracts.js"></script>

--- a/contracts.js
+++ b/contracts.js
@@ -6,6 +6,7 @@ const { db, auth } = initFirebase();
 let userTrade = null;
 let allContracts = [];
 const list = document.getElementById('contract-list');
+const statusEl = document.getElementById('status-msg');
 
 onAuthStateChanged(auth, async user => {
   if (user) {
@@ -73,9 +74,9 @@ async function applyForContract(id) {
       applicant: user.uid,
       createdAt: serverTimestamp()
     });
-    alert('Application submitted');
+    statusEl.textContent = 'Application submitted';
   } catch (err) {
-    alert(err.message);
+    statusEl.textContent = err.message;
   }
 }
 

--- a/post-contract.html
+++ b/post-contract.html
@@ -71,6 +71,7 @@
       <div id="error-msg" class="text-red-500 text-center"></div>
       <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Post Contract</button>
     </form>
+    <div id="status-msg" class="text-red-500 mt-2 text-center"></div>
   </main>
 
   <script type="module">
@@ -82,6 +83,7 @@
     const { auth, db, storage } = initFirebase();
     const form = document.getElementById('contract-form');
     const errorEl = document.getElementById('error-msg');
+    const statusEl = document.getElementById('status-msg');
 
     onAuthStateChanged(auth, async user => {
       if (!user) {
@@ -132,7 +134,7 @@
 
         await addDoc(collection(db, 'contracts'), data);
         form.reset();
-        alert('Contract posted!');
+        statusEl.textContent = 'Contract posted!';
       });
     });
   </script>

--- a/post.html
+++ b/post.html
@@ -55,6 +55,7 @@
       <div id="error-msg" class="text-red-500 text-center"></div>
       <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Post Item</button>
     </form>
+    <div id="status-msg" class="text-red-500 mt-2 text-center"></div>
   </main>
 
   <script type="module">
@@ -66,6 +67,7 @@
     const { auth, db, storage } = initFirebase();
     const form = document.getElementById('item-form');
     const errorEl = document.getElementById('error-msg');
+    const statusEl = document.getElementById('status-msg');
 
     onAuthStateChanged(auth, user => {
       if (!user) {
@@ -106,7 +108,7 @@
 
         await addDoc(collection(db, 'marketplaceItems'), data);
         form.reset();
-        alert('Item posted!');
+        statusEl.textContent = 'Item posted!';
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- add `<div id="status-msg">` to contract-related pages
- show success messages inline instead of using `alert()`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68581d68d15c832ba4deb2a2ea42754b