### PR TITLE
Add Firebase security instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
    - Or create `firebase-config.js` in the project root based on `firebase-config.example.js` and include it before `firebase-init.js` in your HTML.
 3. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.
 
+## Firebase App Check
+
+Protect your backend resources by enabling App Check with reCAPTCHA&nbsp;v3.
+
+1. In the Firebase console open **App Check** and register your web app using the **reCAPTCHA v3** provider.
+2. Copy the generated site key and set it as `appCheckSiteKey` via environment variables or in `firebase-config.js`.
+3. `firebase-init.js` calls `initializeAppCheck` with this key so tokens are automatically refreshed when running in the browser.
+
+See the [Firebase documentation](https://firebase.google.com/docs/app-check/web/recaptcha-provider) for full instructions.
+
+## Production Security Rules
+
+Sample notes mention temporary open rules for Firestore and Realtime Database. Before deploying, write restrictive rules that only allow the actions your app requires.
+
+- Follow the [Firestore Security Rules guide](https://firebase.google.com/docs/firestore/security/get-started) to define document-level permissions and validation.
+- Use the [Realtime Database Rules guide](https://firebase.google.com/docs/database/security) to secure any realtime chat data.
+
+Apply the updated rules in the Firebase console or with the Firebase CLI.
+
 ## Usage
 
 - Sign up via `signup.html` and choose either a professional or personal account.

--- a/firebase-config.example.js
+++ b/firebase-config.example.js
@@ -13,5 +13,7 @@ window.firebaseConfig = {
   storageBucket: '<STORAGE_BUCKET>',
   messagingSenderId: '<MESSAGING_SENDER_ID>',
   appId: '<APP_ID>',
-  measurementId: '<MEASUREMENT_ID>'
+  measurementId: '<MEASUREMENT_ID>',
+  // Public reCAPTCHA v3 key for Firebase App Check
+  appCheckSiteKey: '<APPCHECK_SITE_KEY>'
 };

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -2,6 +2,7 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.7.3/firebas
 import { getAuth } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
 import { getStorage } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+import { initializeAppCheck, ReCaptchaV3Provider } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-app-check.js';
 
 /**
  * Build the Firebase configuration using environment variables when available
@@ -20,7 +21,8 @@ function buildConfig() {
     storageBucket: env.FIREBASE_STORAGE_BUCKET || cfg.storageBucket || '<STORAGE_BUCKET>',
     messagingSenderId: env.FIREBASE_MESSAGING_SENDER_ID || cfg.messagingSenderId || '<MESSAGING_SENDER_ID>',
     appId: env.FIREBASE_APP_ID || cfg.appId || '<APP_ID>',
-    measurementId: env.FIREBASE_MEASUREMENT_ID || cfg.measurementId || '<MEASUREMENT_ID>'
+    measurementId: env.FIREBASE_MEASUREMENT_ID || cfg.measurementId || '<MEASUREMENT_ID>',
+    appCheckSiteKey: env.FIREBASE_APPCHECK_SITE_KEY || cfg.appCheckSiteKey || '<APPCHECK_SITE_KEY>'
   };
 }
 
@@ -32,13 +34,21 @@ let services;
  */
 export function initFirebase() {
   if (!services) {
-    const app = initializeApp(buildConfig());
+    const cfg = buildConfig();
+    const app = initializeApp(cfg);
     services = {
       app,
       auth: getAuth(app),
       db: getFirestore(app),
       storage: getStorage(app)
     };
+
+    if (typeof window !== 'undefined') {
+      services.appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(cfg.appCheckSiteKey),
+        isTokenAutoRefreshEnabled: true
+      });
+    }
   }
   return services;
 }


### PR DESCRIPTION
## Summary
- document enabling Firebase App Check and linking it in `firebase-init.js`
- show example app check site key configuration
- outline crafting production Firestore/Realtime Database rules

## Testing
- `npm test` *(fails: Missing script and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68581d6ad514832ba8758ce7924f89a3