### PR TITLE
Add note on contract form

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ All pages import `firebase-init.js` which centralizes Firebase initialization. S
 
 - Browse contract opportunities on `contracts.html`. Use the sidebar filters to search by text or location.
 - Professional accounts can create new listings from `post-contract.html`.
+- The posting form mirrors the professional profile screen, with familiar text fields, file uploads, and date pickers.
 - Applications are stored in the `applications` subcollection of each contract document.
 
 ### Messaging

--- a/post-contract.html
+++ b/post-contract.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Post Contract – TradeStone</title>
+  <!-- Form layout intentionally parallels create-profile.html -->
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 font-sans pb-16">


### PR DESCRIPTION
## Summary
- highlight that the post contract form mirrors the profile creation workflow
- add a comment in `post-contract.html` referencing `create-profile.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685823256244832b8f11936c661c37b2