### PR TITLE
Add script to seed sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,18 @@ SDK and requires a service account JSON key.
 The script adds the appropriate documents to the `users` collection so the demo
 accounts behave like normal ones and can post in the marketplace or create
 profiles. Deleting removes the auth user and related Firestore document.
+
+### Sample Data
+
+Need some content to showcase the browse pages? Seed Firestore with example
+profiles, contracts and marketplace items using the provided script. Make sure
+`GOOGLE_APPLICATION_CREDENTIALS` points at your service account as described
+above and then run:
+
+```bash
+node scripts/seed-sample-data.js
+```
+
+This will create a handful of fake professionals, contract listings and items so
+the `Browse Professionals`, `Contracts` and `Marketplace` pages display sample
+results.

--- a/scripts/seed-sample-data.js
+++ b/scripts/seed-sample-data.js
@@ -1,0 +1,90 @@
+import admin from 'firebase-admin';
+
+// Initialize using default credentials or service account via GOOGLE_APPLICATION_CREDENTIALS
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+});
+
+const db = admin.firestore();
+
+const profiles = [
+  {
+    businessName: 'Ace Builders',
+    tradeType: 'Builder',
+    location: 'London',
+    travelRadius: 25,
+    description: 'We build quality homes.',
+    avgRating: 4.7,
+  },
+  {
+    businessName: 'Bright Sparks Electrical',
+    tradeType: 'Electrician',
+    location: 'Manchester',
+    travelRadius: 20,
+    description: 'Certified electricians for residential and commercial jobs.',
+    avgRating: 4.9,
+  },
+  {
+    businessName: 'Pipe Pros',
+    tradeType: 'Plumber',
+    location: 'Birmingham',
+    travelRadius: 15,
+    description: 'Emergency plumbing and heating services.',
+    avgRating: 4.5,
+  }
+];
+
+const contracts = [
+  {
+    title: 'Refurbish kitchen',
+    description: 'Looking for a builder to remodel a small kitchen.',
+    location: 'London',
+    budget: 5000,
+    contractType: 'Fixed Price',
+    requiredTrades: ['Builder'],
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  },
+  {
+    title: 'Install new wiring',
+    description: 'Need complete rewiring of a three bedroom house.',
+    location: 'Manchester',
+    budget: 3000,
+    contractType: 'Fixed Price',
+    requiredTrades: ['Electrician'],
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+];
+
+const items = [
+  {
+    title: 'Cordless Drill',
+    description: 'Lightly used cordless drill with two batteries.',
+    price: 80,
+    condition: 'Used',
+    category: 'Tools',
+    location: 'Liverpool',
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  },
+  {
+    title: 'Bulk timber planks',
+    description: 'Mixed hardwood planks, around 30 pieces.',
+    price: 200,
+    condition: 'New',
+    category: 'Materials',
+    location: 'Leeds',
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  }
+];
+
+async function seedCollection(name, data) {
+  for (const entry of data) {
+    const doc = await db.collection(name).add(entry);
+    console.log(`Added ${name}/${doc.id}`);
+  }
+}
+
+await seedCollection('profiles', profiles);
+await seedCollection('contracts', contracts);
+await seedCollection('marketplaceItems', items);
+
+console.log('Sample data added.');


### PR DESCRIPTION
## Summary
- add `seed-sample-data.js` to populate Firestore with demo listings
- document how to run the seeding script in README

## Testing
- `node scripts/manage-test-users.js --help` *(fails: cannot find module)*
- `npm install --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685826132654832b8e398064b7d044c6