### PR TITLE
Add demo placeholder modal

### DIFF
--- a/browse-pros.html
+++ b/browse-pros.html
@@ -50,6 +50,7 @@
   <script type="module">
     import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
     import { initFirebase } from './firebase-init.js'; // Use the centralized Firebase init file
+    import { DEMO_MODE, showDemo } from "./demo-placeholder.js";
 
     const { db } = initFirebase(); // Destructure db from the initialized Firebase app
     let allProfiles = [];
@@ -121,6 +122,18 @@
       portfolioLink.textContent = 'View Portfolio';
 
       linksContainer.append(profileLink, portfolioLink);
+      if (DEMO_MODE) {
+        const demoLink = document.createElement('a');
+        demoLink.href = '#';
+        demoLink.className = 'text-orange-500 block hover:underline';
+        demoLink.textContent = 'Demo Info';
+        demoLink.addEventListener('click', e => {
+          e.preventDefault();
+          const html = `<h2 class="text-lg font-bold mb-2">${profileData.businessName || 'Demo Professional'}</h2><p>Latest review: "Excellent work!"</p><p>Worked previously in ${profileData.location || 'various locations'}.</p>`;
+          showDemo(html);
+        });
+        linksContainer.appendChild(demoLink);
+      }
       card.append(name, trade, locationEl, ratingEl, radiusEl, linksContainer);
       return card;
     }

--- a/contracts.js
+++ b/contracts.js
@@ -1,6 +1,7 @@
 import { initFirebase } from './firebase-init.js';
 import { collection, getDocs, addDoc, serverTimestamp, query, where, doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+import { DEMO_MODE, showDemo } from "./demo-placeholder.js";
 
 const { db, auth } = initFirebase();
 let userTrade = null;
@@ -60,6 +61,18 @@ function createCard(contract) {
   btn.addEventListener('click', () => applyForContract(contract.id));
   card.appendChild(btn);
 
+  if (DEMO_MODE) {
+    const demoLink = document.createElement('a');
+    demoLink.href = '#';
+    demoLink.className = 'text-orange-500 hover:underline';
+    demoLink.textContent = 'Demo Info';
+    demoLink.addEventListener('click', e => {
+      e.preventDefault();
+      const html = `<h2 class="text-lg font-bold mb-2">${contract.title}</h2><p>Budget: £${Number(contract.budget || 0).toFixed(2)}</p><p>Location: ${contract.location || 'various locations'}.</p>`;
+      showDemo(html);
+    });
+    card.appendChild(demoLink);
+  }
   return card;
 }
 

--- a/demo-placeholder.js
+++ b/demo-placeholder.js
@@ -1,0 +1,26 @@
+export const DEMO_MODE = true; // Toggle to false to disable demo placeholders
+
+function ensureDemoModal() {
+  let modal = document.getElementById('demo-modal');
+  if (modal) return modal;
+  modal = document.createElement('div');
+  modal.id = 'demo-modal';
+  modal.className = 'fixed inset-0 bg-black/50 flex items-center justify-center hidden';
+  modal.innerHTML = `
+    <div class="bg-white p-4 rounded w-80 space-y-2 text-center">
+      <div id="demo-content"></div>
+      <button id="demo-close" class="mt-2 px-4 py-1 bg-orange-500 text-white rounded">Close</button>
+    </div>`;
+  document.body.appendChild(modal);
+  modal.querySelector('#demo-close').addEventListener('click', () => {
+    modal.classList.add('hidden');
+  });
+  return modal;
+}
+
+export function showDemo(contentHtml) {
+  if (!DEMO_MODE) return;
+  const modal = ensureDemoModal();
+  modal.querySelector('#demo-content').innerHTML = contentHtml;
+  modal.classList.remove('hidden');
+}

--- a/marketplace.js
+++ b/marketplace.js
@@ -1,5 +1,6 @@
 import { initFirebase } from './firebase-init.js';
 import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+import { DEMO_MODE, showDemo } from "./demo-placeholder.js";
 
 const { db } = initFirebase();
 let allItems = [];
@@ -39,6 +40,18 @@ function createCard(item) {
     card.appendChild(locationEl);
   }
 
+  if (DEMO_MODE) {
+    const demoLink = document.createElement('a');
+    demoLink.href = '#';
+    demoLink.className = 'text-orange-500 block hover:underline';
+    demoLink.textContent = 'Demo Info';
+    demoLink.addEventListener('click', e => {
+      e.preventDefault();
+      const html = `<h2 class="text-lg font-bold mb-2">${item.title}</h2><p>Condition: ${item.condition}</p><p>Located at ${item.location || 'various locations'}.</p>`;
+      showDemo(html);
+    });
+    card.appendChild(demoLink);
+  }
   return card;
 }
 


### PR DESCRIPTION
## Summary
- add demo-placeholder.js with simple modal for temporary data
- link demo modal to professional, marketplace, and contract listings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68582a0f6b60832bbe4ce17c6d3344ec