### PR TITLE
Improve firebase config error display

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
    - Or create `firebase-config.js` in the project root based on `firebase-config.example.js` and include it before `firebase-init.js` in your HTML.
    - After copying, edit `firebase-config.js` and replace every `<PLACEHOLDER>` with the actual values from your Firebase project.
    - When any values are missing, `firebase-init.js` now throws an error listing the fields that still need configuration.
+   - The same error text is also inserted at the top of the page so you immediately know setup isn't complete.
 3. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.
 
 ## Firebase App Check

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -46,7 +46,18 @@ let services;
  */
 export function initFirebase() {
   if (!services) {
-    const cfg = buildConfig();
+    let cfg;
+    try {
+      cfg = buildConfig();
+    } catch (err) {
+      if (typeof document !== 'undefined') {
+        const el = document.createElement('div');
+        el.textContent = err.message;
+        el.style.cssText = 'background:#fee;color:#b00;border:1px solid #f00;margin:1em;padding:.5em';
+        document.body.prepend(el);
+      }
+      throw err;
+    }
     const app = initializeApp(cfg);
     services = {
       app,


### PR DESCRIPTION
## Summary
- show missing config errors on the page when init fails
- clarify README about visible error message

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68585746992c832b8b28fe46d8a3bd91