### PR TITLE
Clarify Firebase config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Firebase powers authentication, Firestore storage, and hosting of profile images
 2. Provide the credentials using environment variables or a config file:
    - Set variables like `FIREBASE_API_KEY` and `FIREBASE_AUTH_DOMAIN` when bundling/serving the app.
    - Or create `firebase-config.js` in the project root based on `firebase-config.example.js` and include it before `firebase-init.js` in your HTML.
-   - After copying, edit `firebase-config.js` and replace every `<PLACEHOLDER>` with the actual values from your Firebase project.
+     `firebase-config.js` is listed in `.gitignore` so you can store your real
+     credentials locally without committing them.
+   - After copying, edit `firebase-config.js` and replace every `<PLACEHOLDER>`
+     with the actual values from your Firebase project.
    - When any values are missing, `firebase-init.js` now throws an error listing the fields that still need configuration.
    - The same error text is also inserted at the top of the page so you immediately know setup isn't complete.
 3. Serve the static files using any web server (for example `npx serve .`) or open the HTML files directly in the browser.

--- a/firebase-config.example.js
+++ b/firebase-config.example.js
@@ -2,8 +2,9 @@
  * Example configuration file for Firebase credentials.
  *
  * Copy this file to `firebase-config.js` and replace the placeholder values
- * with your project's Firebase configuration. Include the file in your HTML
- * before loading `firebase-init.js`.
+ * with your project's Firebase configuration. The new file is ignored by git
+ * so your secrets stay local. Include the file in your HTML before loading
+ * `firebase-init.js`.
  */
 window.firebaseConfig = {
   apiKey: '<API_KEY>',


### PR DESCRIPTION
## Summary
- document that `firebase-config.js` is ignored and should be created locally
- update example config with note that the generated file is ignored by git

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685859d868e8832bbe187856ceff1d54