### PR TITLE
Add script to seed blog content

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,13 @@ node scripts/seed-sample-data.js
 This will create a handful of fake professionals, contract listings and items so
 the `Browse Professionals`, `Contracts` and `Marketplace` pages display sample
 results.
+
+Need some demo discussions on the blog as well? Seed a few example posts and
+comments with:
+
+```bash
+node scripts/seed-blog-posts.js
+```
+
+Running the script populates the `posts` collection and nested `comments`
+subcollections so the Blog pages show content right away.

--- a/scripts/seed-blog-posts.js
+++ b/scripts/seed-blog-posts.js
@@ -1,0 +1,61 @@
+import admin from 'firebase-admin';
+
+// Initialize using default credentials or service account via GOOGLE_APPLICATION_CREDENTIALS
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+});
+
+const db = admin.firestore();
+
+const posts = [
+  {
+    title: 'How do I fix a leaky faucet?',
+    content: 'I\'ve got a persistent drip from my kitchen faucet. What\'s the quickest DIY fix before I call a plumber?',
+    comments: [
+      'Try replacing the washer inside the handle first. It\'s usually a cheap fix.',
+    ],
+  },
+  {
+    title: 'Best way to insulate a garage?',
+    content: 'I\'m converting my detached garage into a workshop and want to keep the temperature stable. Any tips on insulation?',
+    comments: [
+      'Rigid foam boards on the walls and batt insulation in the ceiling worked well for me.',
+      'Don\'t forget to weatherstrip the door too!',
+    ],
+  },
+  {
+    title: 'Tips for painting exterior walls?',
+    content: 'About to repaint the outside of my house. Should I use a primer first or does the modern paint include it?',
+    comments: [
+      'Always prime if the old paint is flaking or if you\'re changing color drastically.',
+    ],
+  },
+];
+
+async function seed() {
+  for (const p of posts) {
+    const docRef = await db.collection('posts').add({
+      authorId: 'demo-seeder',
+      title: p.title,
+      content: p.content,
+      hammerCount: 0,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    for (const text of p.comments) {
+      await db
+        .collection('posts')
+        .doc(docRef.id)
+        .collection('comments')
+        .add({
+          authorId: 'demo-seeder',
+          text,
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+    }
+    console.log(`Added posts/${docRef.id}`);
+  }
+}
+
+await seed();
+console.log('Sample blog posts added.');


### PR DESCRIPTION
## Summary
- add `seed-blog-posts.js` script to populate the `posts` and comments collections with demo data
- document blog seeding in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876698b76e8832ba82b80d2dd89f76c