### PR TITLE
Redirect new signups to profile creation

### DIFF
--- a/create-personal-profile.html
+++ b/create-personal-profile.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create Personal Profile – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+    <h1 class="text-2xl font-bold mb-6 text-center">Personal Profile</h1>
+    <form id="profile-form" class="space-y-4" enctype="multipart/form-data">
+      <div>
+        <label for="displayName" class="block mb-1">Full Name</label>
+        <input id="displayName" name="displayName" type="text" required class="w-full p-2 border rounded" />
+      </div>
+      <div>
+        <label for="avatar" class="block mb-1">Avatar</label>
+        <input id="avatar" name="avatar" type="file" accept="image/*" class="w-full" />
+      </div>
+      <div>
+        <label for="location" class="block mb-1">Location</label>
+        <input id="location" name="location" type="text" class="w-full p-2 border rounded" />
+      </div>
+      <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">Save Profile</button>
+    </form>
+    <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
+  </main>
+
+  <div class="text-center mt-6">
+    <a href="index.html" class="inline-flex items-center text-gray-600 hover:text-gray-800">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-16.5A.75.75 0 013 21V9.75z" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 22V12h6v10" />
+      </svg>
+    </a>
+  </div>
+
+  <script src="firebase-config.js"></script>
+  <script type="module">
+    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+    import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+    import { ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+    import { initFirebase } from './firebase-init.js';
+
+    const { auth, db, storage } = initFirebase();
+    const form = document.getElementById('profile-form');
+    const errorEl = document.getElementById('error-msg');
+
+    onAuthStateChanged(auth, user => {
+      if (!user) {
+        window.location.href = 'login.html';
+        return;
+      }
+
+      form.addEventListener('submit', async e => {
+        e.preventDefault();
+        errorEl.textContent = '';
+        const data = {
+          displayName: form.displayName.value,
+          location: form.location.value
+        };
+
+        const file = form.avatar.files[0];
+        if (file) {
+          const fileRef = ref(storage, `users/${user.uid}/avatar-${Date.now()}-${file.name}`);
+          try {
+            await uploadBytes(fileRef, file);
+            data.avatarUrl = await getDownloadURL(fileRef);
+          } catch (err) {
+            errorEl.textContent = 'Failed to upload avatar: ' + err.message;
+            return;
+          }
+        }
+
+        try {
+          await setDoc(doc(db, 'users', user.uid), data, { merge: true });
+          window.location.href = 'personal-dashboard.html';
+        } catch (err) {
+          errorEl.textContent = err.message;
+        }
+      });
+    });
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html')
+      .then(res => res.text())
+      .then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>

--- a/personal-signup.html
+++ b/personal-signup.html
@@ -122,7 +122,7 @@
         if (accountType === 'professional') {
           window.location.href = 'create-profile.html';
         } else {
-          window.location.href = 'personal-dashboard.html';
+          window.location.href = 'create-personal-profile.html';
         }
       } catch(err) {
         // Display Firebase authentication errors directly on the page

--- a/professional-signup.html
+++ b/professional-signup.html
@@ -122,7 +122,7 @@
         if (accountType === 'professional') {
           window.location.href = 'create-profile.html';
         } else {
-          window.location.href = 'personal-dashboard.html';
+          window.location.href = 'create-personal-profile.html';
         }
       } catch(err) {
         // Display Firebase authentication errors directly on the page


### PR DESCRIPTION
## Summary
- create a personal profile page to capture a name, avatar and location
- after signing up, direct users to the appropriate profile creation page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876729c6cd4832bb58ea3b2e64ef3fa