### PR TITLE
Add Firebase configuration file

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,23 @@
+/* 
+ * Local Firebase configuration for the TradeStone demo.
+ *
+ * Populate this file with your own project’s configuration values.  These
+ * values are injected into `firebase-init.js` via the global
+ * `window.firebaseConfig` object.  Do not commit real API keys or service
+ * account details to version control.
+ */
+
+window.firebaseConfig = {
+  apiKey: "AIzaSyAjA_fDLdSbIW6eRFDe4oKpfdB8O4Ix4zo",
+  authDomain: "tradestone-efb30.firebaseapp.com",
+  databaseURL: "https://tradestone-efb30-default-rtdb.firebaseio.com",
+  projectId: "tradestone-efb30",
+  storageBucket: "tradestone-efb30.firebasestorage.app",
+  messagingSenderId: "761717818779",
+  appId: "1:761717818779:web:05287865a076dbfed68d3e",
+  measurementId: "G-TM9DK5H25J"
+};
+
+// To enable Firebase App Check with reCAPTCHA v3, add the following line
+// using the site key generated in the Firebase console:
+// appCheckSiteKey: "<your-recaptcha-v3-site-key>"


### PR DESCRIPTION
## Summary
- provide firebase-config.js with TradeStone demo project credentials for initialization

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node scripts/manage-test-users.js create` *(fails: Failed to determine project ID: getaddrinfo ENOTFOUND metadata.google.internal)*

------
https://chatgpt.com/codex/tasks/task_e_688fa2aa73dc832b8d825496ea273691