### PR TITLE
feat: modernize core pages with new styles

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,4 +1,4 @@
-<header class="sticky top-0 z-50 relative flex items-center justify-between p-4 bg-white shadow">
+<header class="sticky top-0 z-50 relative flex items-center justify-between p-4 bg-white/80 backdrop-blur shadow">
   <!-- Centered logo and name -->
   <div class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-2">
     <a href="index.html">

--- a/index.html
+++ b/index.html
@@ -7,8 +7,9 @@
   <title>TradeStone</title>
   <!-- Tailwind CSS via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
 
   <!-- Reusable Header -->
   <div id="header"></div>
@@ -31,14 +32,8 @@
   <!-- Call-to-action for Login / Sign Up -->
   <section class="px-4 pb-8 text-center">
     <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
-      <a href="signup.html"
-         class="px-8 py-4 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold focus:ring-2 focus:ring-orange-500">
-        Sign Up
-      </a>
-      <a href="login.html"
-         class="px-8 py-4 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold focus:ring-2 focus:ring-orange-500">
-        Log In
-      </a>
+      <a href="signup.html" class="btn-primary">Sign Up</a>
+      <a href="login.html" class="btn-secondary">Log In</a>
     </div>
   </section>
 
@@ -47,7 +42,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
       <!-- Card 1 -->
       <a href="marketplace.html" class="block">
-      <div class="bg-white rounded-xl shadow p-4 text-center">
+      <div class="bg-white rounded-xl shadow p-4 text-center card">
         <svg aria-hidden="true" class="h-10 w-10 mx-auto mb-2 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round"
                 d="M3 3h2l.4 2M7 13h10l4-8H5.4
@@ -61,7 +56,7 @@
       </a>
       <!-- Card 2 -->
       <a href="browse-pros.html" class="block">
-        <div class="bg-white rounded-xl shadow p-4 text-center">
+        <div class="bg-white rounded-xl shadow p-4 text-center card">
           <svg aria-hidden="true" class="h-10 w-10 mx-auto mb-2 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round"
                   d="M15.75 6a3.75 3.75 0 1 1-7.5 0
@@ -76,7 +71,7 @@
       </a>
       <!-- Card 3 -->
       <a href="contracts.html" class="block">
-      <div class="bg-white rounded-xl shadow p-4 text-center">
+      <div class="bg-white rounded-xl shadow p-4 text-center card">
         <svg aria-hidden="true" class="h-10 w-10 mx-auto mb-2 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round"
                 d="M7 7h10M7 11h6m-6 4h10M5 3h14a2

--- a/login.html
+++ b/login.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Choose Login Type – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
@@ -16,10 +17,10 @@
   <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-6">
     <h1 class="text-2xl font-bold">Log In</h1>
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="professional-login.html" class="px-6 py-3 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold">Professional Login</a>
-      <a href="personal-login.html" class="px-6 py-3 border border-orange-600 text-orange-600 hover:bg-orange-50 rounded-lg font-semibold">Personal Login</a>
+      <a href="professional-login.html" class="btn-secondary">Professional Login</a>
+      <a href="personal-login.html" class="btn-secondary">Personal Login</a>
     </div>
-    <p class="text-sm">Need an account? <a href="signup.html" class="text-orange-600 font-medium">Sign up</a></p>
+    <p class="text-sm">Need an account? <a href="signup.html" class="text-orange-600 font-medium hover:underline">Sign up</a></p>
   </main>
 
   <div id="footer"></div>

--- a/signup.html
+++ b/signup.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Choose Account Type – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
@@ -16,10 +17,10 @@
   <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-6">
     <h1 class="text-2xl font-bold">Sign Up</h1>
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="professional-signup.html" class="px-6 py-3 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold">Professional Sign Up</a>
-      <a href="personal-signup.html" class="px-6 py-3 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-semibold">Personal Sign Up</a>
+      <a href="professional-signup.html" class="btn-primary">Professional Sign Up</a>
+      <a href="personal-signup.html" class="btn-primary">Personal Sign Up</a>
     </div>
-    <p class="text-sm">Already have an account? <a href="login.html" class="text-orange-600 font-medium">Log in</a></p>
+    <p class="text-sm">Already have an account? <a href="login.html" class="text-orange-600 font-medium hover:underline">Log in</a></p>
   </main>
 
   <div id="footer"></div>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,49 @@
+/* Global Styles to modernize look */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(180deg, #f9fafb 0%, #ffffff 100%);
+  min-height: 100vh;
+}
+
+/* Card component */
+.card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
+}
+
+/* Buttons */
+.btn-primary {
+  padding: 1rem 2rem;
+  background-color: #ea580c; /* orange-600 */
+  color: #fff;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  display: inline-block;
+}
+.btn-primary:hover {
+  background-color: #c2410c; /* orange-700 */
+  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
+  transform: translateY(-2px);
+}
+
+.btn-secondary {
+  padding: 1rem 2rem;
+  color: #ea580c; /* orange-600 */
+  border: 2px solid #ea580c;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  display: inline-block;
+}
+.btn-secondary:hover {
+  background-color: #fff7ed; /* orange-50 */
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  transform: translateY(-2px);
+}


### PR DESCRIPTION
## Summary
- add global stylesheet for modern font, gradient background, and reusable button/card styles
- revamp landing, login, and signup pages to use new modern components
- soften header with translucent background and blur effect

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68972682aa18832bbcf6c44439dca6c4