### PR TITLE
Modernise landing + header to match new demo (hero illustration, colors, typography)

### DIFF
--- a/assets/hero-illustration.svg
+++ b/assets/hero-illustration.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2C3E50"/>
+      <stop offset="100%" stop-color="#E67E22"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)"/>
+
+  <!-- Handshake -->
+  <path d="M150 450 l120 -120 80 80 80 -80 120 120" stroke="#F9F9F9" stroke-width="20" stroke-linecap="round" fill="none"/>
+
+  <!-- Contract -->
+  <rect x="520" y="230" width="200" height="300" rx="10" fill="#F9F9F9" stroke="#2C3E50" stroke-width="10"/>
+  <line x1="540" y1="280" x2="700" y2="280" stroke="#2C3E50" stroke-width="10"/>
+  <line x1="540" y1="320" x2="700" y2="320" stroke="#2C3E50" stroke-width="10"/>
+  <line x1="540" y1="360" x2="700" y2="360" stroke="#2C3E50" stroke-width="10"/>
+
+  <!-- Wrench -->
+  <path d="M900 250 l-80 80 100 100 80 -80" stroke="#F9F9F9" stroke-width="20" stroke-linecap="round" fill="none"/>
+  <circle cx="880" cy="470" r="40" stroke="#F9F9F9" stroke-width="20" fill="none"/>
+</svg>

--- a/header.html
+++ b/header.html
@@ -1,40 +1,31 @@
-<header class="sticky top-0 z-50 relative flex items-center justify-between p-4 bg-white/80 backdrop-blur shadow">
-  <!-- Centered logo and name -->
-  <div class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-2">
-    <a href="index.html">
-      <img src="TradeStone%20Logo.png" alt="TradeStone logo" class="h-8 w-auto">
-    </a>
-    <h1 class="text-xl font-bold">TradeStone</h1>
-  </div>
+<header class="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-sm shadow-md z-50">
+  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --primary: #E67E22;   /* warm orange */
+      --secondary: #2C3E50; /* dark blue-grey */
+      --neutral-bg: #F9F9F9;
+    }
+    body { font-family: 'Inter', sans-serif; background-color: var(--neutral-bg); }
+  </style>
 
-  <!-- Right side icons -->
-  <div class="ml-auto flex items-center space-x-4">
-    <!-- Burger menu button visible on all screen sizes -->
-    <button id="burger-btn" class="focus:outline-none">
-      <span class="sr-only">Menu</span>
-      <svg class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    </button>
-    <!-- Profile icon -->
-    <a id="profile-link" href="login.html">
-      <span class="sr-only">Dashboard</span>
-      <svg class="h-6 w-6 text-gray-700" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
-      </svg>
+  <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+    <a href="index.html" class="flex items-center space-x-2">
+      <img src="TradeStone Logo.png" alt="TradeStone logo" class="h-8 w-auto" />
+      <span class="font-bold text-xl">TradeStone</span>
     </a>
-  </div>
 
-  <!-- Dropdown menu -->
-  <div id="burger-menu" class="hidden fixed inset-y-0 right-0 w-64 transform translate-x-full transition-transform bg-white border-l border-gray-200 p-4 space-y-2">
-    <a href="browse-pros.html" class="block px-4 py-2 hover:bg-gray-100">Browse</a>
-    <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-100">Marketplace</a>
-    <a href="contracts.html" class="block px-4 py-2 hover:bg-gray-100">Contracts</a>
-    <a href="post-contract.html" class="block px-4 py-2 hover:bg-gray-100">Post Contract</a>
-    <a href="post.html" class="block px-4 py-2 hover:bg-gray-100">Post Item</a>
-    <a href="blog.html" class="block px-4 py-2 hover:bg-gray-100">Blog</a>
-    <a href="messages.html" class="block px-4 py-2 hover:bg-gray-100">Messages</a>
-    <a href="signup.html" class="block px-4 py-2 hover:bg-gray-100">Sign Up</a>
-    <a href="login.html" class="block px-4 py-2 hover:bg-gray-100">Log In</a>
+    <nav class="hidden md:flex items-center space-x-6">
+      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Browse</a>
+      <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>
+      <a href="contracts.html" class="hover:text-[var(--primary)]">Contracts</a>
+      <a href="blog.html" class="hover:text-[var(--primary)]">Blog</a>
+    </nav>
+
+    <div class="flex items-center space-x-4">
+      <a href="login.html" class="text-sm hover:text-[var(--primary)]">Log In</a>
+      <a href="signup.html" class="px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:bg-orange-700 transition-colors">Sign Up</a>
+    </div>
   </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -18,22 +18,20 @@
     loadHeader();
   </script>
   <main>
-  <!-- Hero / Intro -->
-  <section class="px-4 py-6 text-center">
-    <h2 class="text-5xl font-extrabold mb-2">Welcome to TradeStone</h2>
-    <p class="text-gray-700 text-xl mb-2">
-      Grow your business with TradeStone – the absolute platform for tradespeople.
-    </p>
-    <p class="text-gray-700 text-xl mb-6">
-      Buy and sell excess materials, win more work, and connect with the right clients. All right here.
-    </p>
-  </section>
-
-  <!-- Call-to-action for Login / Sign Up -->
-  <section class="px-4 pb-8 text-center">
-    <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
-      <a href="signup.html" class="btn-primary">Sign Up</a>
-      <a href="login.html" class="btn-secondary">Log In</a>
+  <!-- Hero Section -->
+  <section class="relative h-[70vh] flex items-center justify-center text-center text-white mt-14">
+    <img src="assets/hero-illustration.svg" alt="abstract trade & contracts background"
+         class="absolute inset-0 w-full h-full object-cover" />
+    <div class="absolute inset-0 bg-gradient-to-b from-[var(--secondary)/70] to-[var(--secondary)/30]"></div>
+    <div class="relative z-10 px-4">
+      <h1 class="text-5xl font-extrabold mb-4">Build & Grow with TradeStone</h1>
+      <p class="text-lg mb-8 max-w-xl mx-auto">
+        Connect with professionals, buy surplus materials, and win contracts with ease.
+      </p>
+      <a href="signup.html"
+         class="px-6 py-3 bg-[var(--primary)] text-white rounded-lg font-semibold hover:bg-orange-700 transition-colors">
+        Get Started
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- overhaul header with fixed translucent bar, Inter font, and primary/secondary color vars
- replace landing hero with abstract trade illustration and gradient overlay
- swap PNG hero asset for inline SVG to avoid binary file issues

## Testing
- `python3 -m http.server` then `curl -I http://127.0.0.1:8000/index.html`
- `curl -I http://127.0.0.1:8000/assets/hero-illustration.svg`


------
https://chatgpt.com/codex/tasks/task_e_689729d1d42c832ba6a803d51cf175ec