### PR TITLE
Modernise landing + header to match new demo (hero illustration, colors, typography)

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,14 +6,14 @@
   <title>About – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center">
     <h1 class="text-2xl font-bold mb-4">About TradeStone</h1>
     <p class="mb-4">At TradeStone, we’re aiming to build the Globes most trusted platform for tradespeople, contractors, and DIYers. Our mission is simple: to connect skilled professionals, resourceful individuals, and top-quality materials—all in one place.</p>
 

--- a/account-settings.html
+++ b/account-settings.html
@@ -6,13 +6,13 @@
   <title>Account Settings – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow space-y-6">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow space-y-6">
     <h1 class="text-2xl font-bold text-center">Account Settings</h1>
     <p class="text-center">Logged in as: <span id="current-email" class="font-medium"></span></p>
 

--- a/assets/hero-illustration.svg
+++ b/assets/hero-illustration.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2C3E50"/>
+      <stop offset="100%" stop-color="#E67E22"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)"/>
+
+  <!-- Handshake -->
+  <path d="M150 450 l120 -120 80 80 80 -80 120 120" stroke="#F9F9F9" stroke-width="20" stroke-linecap="round" fill="none"/>
+
+  <!-- Contract -->
+  <rect x="520" y="230" width="200" height="300" rx="10" fill="#F9F9F9" stroke="#2C3E50" stroke-width="10"/>
+  <line x1="540" y1="280" x2="700" y2="280" stroke="#2C3E50" stroke-width="10"/>
+  <line x1="540" y1="320" x2="700" y2="320" stroke="#2C3E50" stroke-width="10"/>
+  <line x1="540" y1="360" x2="700" y2="360" stroke="#2C3E50" stroke-width="10"/>
+
+  <!-- Wrench -->
+  <path d="M900 250 l-80 80 100 100 80 -80" stroke="#F9F9F9" stroke-width="20" stroke-linecap="round" fill="none"/>
+  <circle cx="880" cy="470" r="40" stroke="#F9F9F9" stroke-width="20" fill="none"/>
+</svg>

--- a/blog-post.html
+++ b/blog-post.html
@@ -6,14 +6,14 @@
   <title>Post – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 id="title" class="text-2xl font-bold mb-2"></h2>
     <p id="content" class="mb-4"></p>
     <button id="hammer-btn" class="bg-orange-500 text-white px-3 py-1 rounded mb-4">Hammer (<span id="hammer-count">0</span>)</button>

--- a/blog.html
+++ b/blog.html
@@ -6,14 +6,14 @@
   <title>Blog – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 class="text-2xl font-bold mb-4">Blog</h2>
     <div class="mb-4">
       <input id="search" type="text" class="w-full p-2 border rounded" placeholder="Search posts" />

--- a/browse-pros.html
+++ b/browse-pros.html
@@ -6,7 +6,7 @@
   <title>Browse Professionals – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';

--- a/business-manager.html
+++ b/business-manager.html
@@ -6,13 +6,13 @@
   <title>Business Manager – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
-  <main class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-4 text-center">Business Manager</h1>
 
     <div id="tabs" class="flex space-x-4 mb-4">

--- a/contract-detail.html
+++ b/contract-detail.html
@@ -6,14 +6,14 @@
   <title>Contract Detail – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main id="contract-content" class="max-w-2xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main id="contract-content" class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 id="contract-title" class="text-2xl font-bold mb-2"></h2>
     <p id="contract-description" class="mb-4"></p>
     <p id="contract-budget" class="text-gray-700"></p>

--- a/contracts.html
+++ b/contracts.html
@@ -6,7 +6,7 @@
   <title>Contracts – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';

--- a/create-personal-profile.html
+++ b/create-personal-profile.html
@@ -6,14 +6,14 @@
   <title>Create Personal Profile – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Personal Profile</h1>
     <form id="profile-form" class="space-y-4" enctype="multipart/form-data">
       <div>

--- a/create-profile.html
+++ b/create-profile.html
@@ -6,7 +6,7 @@
   <title>Create Profile – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
@@ -21,7 +21,7 @@
     });
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Professional Profile</h1>
     <form id="profile-form" class="space-y-4" enctype="multipart/form-data">
       <div>

--- a/edit-profile.html
+++ b/edit-profile.html
@@ -6,7 +6,7 @@
   <title>Edit Profile – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
@@ -21,7 +21,7 @@
     });
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h2 class="text-2xl font-semibold mb-6 text-center">Edit Profile</h2>
     <form id="profile-form" class="space-y-4" enctype="multipart/form-data">
       <div>

--- a/header.html
+++ b/header.html
@@ -1,40 +1,36 @@
-<header class="sticky top-0 z-50 relative flex items-center justify-between p-4 bg-white/80 backdrop-blur shadow">
-  <!-- Centered logo and name -->
-  <div class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-2">
-    <a href="index.html">
-      <img src="TradeStone%20Logo.png" alt="TradeStone logo" class="h-8 w-auto">
-    </a>
-    <h1 class="text-xl font-bold">TradeStone</h1>
-  </div>
+<header class="fixed top-0 left-0 right-0 bg-white/80 backdrop-blur-sm shadow-md z-50">
+  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --primary: #E67E22;   /* warm orange */
+      --secondary: #2C3E50; /* dark blue-grey */
+      --neutral-bg: #F9F9F9;
+    }
+    /* Apply base typography, background and space for the fixed header */
+    body {
+      font-family: 'Inter', sans-serif;
+      background-color: var(--neutral-bg);
+      padding-top: 4rem; /* prevent content being hidden behind header */
+    }
+  </style>
 
-  <!-- Right side icons -->
-  <div class="ml-auto flex items-center space-x-4">
-    <!-- Burger menu button visible on all screen sizes -->
-    <button id="burger-btn" class="focus:outline-none">
-      <span class="sr-only">Menu</span>
-      <svg class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    </button>
-    <!-- Profile icon -->
-    <a id="profile-link" href="login.html">
-      <span class="sr-only">Dashboard</span>
-      <svg class="h-6 w-6 text-gray-700" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
-      </svg>
+  <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+    <a href="index.html" class="flex items-center space-x-2">
+      <img src="TradeStone Logo.png" alt="TradeStone logo" class="h-8 w-auto" />
+      <span class="font-bold text-xl">TradeStone</span>
     </a>
-  </div>
 
-  <!-- Dropdown menu -->
-  <div id="burger-menu" class="hidden fixed inset-y-0 right-0 w-64 transform translate-x-full transition-transform bg-white border-l border-gray-200 p-4 space-y-2">
-    <a href="browse-pros.html" class="block px-4 py-2 hover:bg-gray-100">Browse</a>
-    <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-100">Marketplace</a>
-    <a href="contracts.html" class="block px-4 py-2 hover:bg-gray-100">Contracts</a>
-    <a href="post-contract.html" class="block px-4 py-2 hover:bg-gray-100">Post Contract</a>
-    <a href="post.html" class="block px-4 py-2 hover:bg-gray-100">Post Item</a>
-    <a href="blog.html" class="block px-4 py-2 hover:bg-gray-100">Blog</a>
-    <a href="messages.html" class="block px-4 py-2 hover:bg-gray-100">Messages</a>
-    <a href="signup.html" class="block px-4 py-2 hover:bg-gray-100">Sign Up</a>
-    <a href="login.html" class="block px-4 py-2 hover:bg-gray-100">Log In</a>
+    <nav class="hidden md:flex items-center space-x-6">
+      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Browse</a>
+      <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>
+      <a href="contracts.html" class="hover:text-[var(--primary)]">Contracts</a>
+      <a href="blog.html" class="hover:text-[var(--primary)]">Blog</a>
+    </nav>
+
+    <div class="flex items-center space-x-4">
+      <a href="login.html" class="text-sm hover:text-[var(--primary)]">Log In</a>
+      <a href="signup.html" class="px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:bg-orange-700 transition-colors">Sign Up</a>
+    </div>
   </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -18,22 +18,20 @@
     loadHeader();
   </script>
   <main>
-  <!-- Hero / Intro -->
-  <section class="px-4 py-6 text-center">
-    <h2 class="text-5xl font-extrabold mb-2">Welcome to TradeStone</h2>
-    <p class="text-gray-700 text-xl mb-2">
-      Grow your business with TradeStone – the absolute platform for tradespeople.
-    </p>
-    <p class="text-gray-700 text-xl mb-6">
-      Buy and sell excess materials, win more work, and connect with the right clients. All right here.
-    </p>
-  </section>
-
-  <!-- Call-to-action for Login / Sign Up -->
-  <section class="px-4 pb-8 text-center">
-    <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
-      <a href="signup.html" class="btn-primary">Sign Up</a>
-      <a href="login.html" class="btn-secondary">Log In</a>
+  <!-- Hero Section -->
+  <section class="relative h-[70vh] flex items-center justify-center text-center text-white">
+    <img src="assets/hero-illustration.svg" alt="abstract trade & contracts background"
+         class="absolute inset-0 w-full h-full object-cover" />
+    <div class="absolute inset-0 bg-gradient-to-b from-[var(--secondary)/70] to-[var(--secondary)/30]"></div>
+    <div class="relative z-10 px-4">
+      <h1 class="text-5xl font-extrabold mb-4">Build & Grow with TradeStone</h1>
+      <p class="text-lg mb-8 max-w-xl mx-auto">
+        Connect with professionals, buy surplus materials, and win contracts with ease.
+      </p>
+      <a href="signup.html"
+         class="px-6 py-3 bg-[var(--primary)] text-white rounded-lg font-semibold hover:bg-orange-700 transition-colors">
+        Get Started
+      </a>
     </div>
   </section>
 

--- a/login.html
+++ b/login.html
@@ -14,7 +14,7 @@
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-6">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center space-y-6">
     <h1 class="text-2xl font-bold">Log In</h1>
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
       <a href="professional-login.html" class="btn-secondary">Professional Login</a>

--- a/marketplace.html
+++ b/marketplace.html
@@ -6,7 +6,7 @@
   <title>Marketplace – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';

--- a/messages.html
+++ b/messages.html
@@ -6,7 +6,7 @@
   <title>Messages – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
 
   <!-- Header -->
   <div id="header"></div>
@@ -16,7 +16,7 @@
   </script>
 
   <!-- Main Content -->
-  <main class="max-w-4xl mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-4xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 class="text-2xl font-bold mb-4 text-center">Messages</h2>
     <div class="flex">
       <aside id="conversation-list" class="w-1/3 border-r pr-4"></aside>

--- a/personal-dashboard.html
+++ b/personal-dashboard.html
@@ -6,13 +6,13 @@
   <title>Personal Dashboard – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center">
     <h1 class="text-2xl font-bold mb-4">Welcome, Personal User!</h1>
     <p class="mb-4">Logged in as: <span id="user-email" class="font-medium"></span></p>
     <button id="logout-btn"

--- a/personal-login.html
+++ b/personal-login.html
@@ -6,14 +6,14 @@
   <title>Personal Login – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Personal Login</h1>
     <form id="login-form" class="space-y-4">
       <div>

--- a/personal-signup.html
+++ b/personal-signup.html
@@ -6,14 +6,14 @@
   <title>Personal Sign Up – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Create Personal Account</h1>
     <form id="signup-form" class="space-y-4">
       <input type="hidden" name="accountType" value="personal"/>

--- a/portfolio.html
+++ b/portfolio.html
@@ -6,7 +6,7 @@
   <title>Portfolio – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
 
   <!-- Header -->
   <div id="header"></div>
@@ -16,7 +16,7 @@
   </script>
 
   <!-- Portfolio Gallery -->
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h2 class="text-xl font-semibold mb-4 text-center">Portfolio</h2>
     <div id="portfolio-grid" class="grid grid-cols-2 gap-4"></div>
   </main>

--- a/post-contract.html
+++ b/post-contract.html
@@ -7,7 +7,7 @@
   <!-- Form layout intentionally parallels create-profile.html -->
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
@@ -22,7 +22,7 @@
     });
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h2 class="text-2xl font-bold mb-4 text-center">Post Contract</h2>
     <form id="contract-form" class="space-y-4" enctype="multipart/form-data">
       <div>

--- a/post.html
+++ b/post.html
@@ -6,14 +6,14 @@
   <title>Post Item – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h2 class="text-2xl font-bold mb-4 text-center">Post Item</h2>
     <form id="item-form" class="space-y-4" enctype="multipart/form-data">
       <div>

--- a/privacy.html
+++ b/privacy.html
@@ -6,14 +6,14 @@
   <title>Privacy Policy – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-4 text-center">Privacy Policy</h1>
     <p>This is a placeholder for the privacy policy.</p>
   </main>

--- a/professional-dashboard.html
+++ b/professional-dashboard.html
@@ -6,13 +6,13 @@
   <title>Professional Dashboard – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center">
     <h1 class="text-2xl font-bold mb-4">Welcome, Professional!</h1>
     <p class="mb-4">Logged in as: <span id="user-email" class="font-medium"></span></p>
 

--- a/professional-login.html
+++ b/professional-login.html
@@ -6,14 +6,14 @@
   <title>Professional Login – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Professional Login</h1>
     <form id="login-form" class="space-y-4">
       <div>

--- a/professional-profile.html
+++ b/professional-profile.html
@@ -6,7 +6,7 @@
   <title>Professional Profile – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
 
   <!-- Reusable Header -->
   <div id="header"></div>
@@ -16,7 +16,7 @@
   </script>
 
   <!-- Profile Content -->
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-4">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center space-y-4">
     <img id="logo" alt="" class="w-32 h-32 mx-auto object-contain hidden" />
     <h2 id="businessName" class="text-2xl font-bold"></h2>
     <p id="companyId" class="text-sm text-gray-700"></p>

--- a/professional-signup.html
+++ b/professional-signup.html
@@ -6,14 +6,14 @@
   <title>Professional Sign Up – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Create Professional Account</h1>
     <form id="signup-form" class="space-y-4">
       <input type="hidden" name="accountType" value="professional"/>

--- a/signup.html
+++ b/signup.html
@@ -14,7 +14,7 @@
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow text-center space-y-6">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center space-y-6">
     <h1 class="text-2xl font-bold">Sign Up</h1>
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
       <a href="professional-signup.html" class="btn-primary">Professional Sign Up</a>

--- a/terms.html
+++ b/terms.html
@@ -6,14 +6,14 @@
   <title>Terms of Service – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans pb-16">
+<body class="text-gray-900 font-sans pb-16">
   <div id="header"></div>
   <script type="module">
     import { loadHeader } from './loadHeader.js';
     loadHeader();
   </script>
 
-  <main class="max-w-md mx-auto mt-12 p-4 bg-white rounded-xl shadow">
+  <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
     <h1 class="text-2xl font-bold mb-2 text-center">Terms of Service</h1>
     <p class="text-sm italic mb-4 text-center">Last Updated: 10th June 2025</p>
     <p class="mb-4">Welcome to TradeStone. By accessing or using our website, mobile application, or services, you agree to the following Terms of Service. Please read them carefully.</p>


### PR DESCRIPTION
## Summary
- overhaul header with fixed translucent bar, Inter font, and primary/secondary color vars
- replace landing hero with abstract trade illustration and gradient overlay
- apply global header spacing and remove legacy page margins/backgrounds for a consistent look across all pages

## Testing
- `python3 -m http.server` then `curl -I http://127.0.0.1:8000/index.html`
- `curl -I http://127.0.0.1:8000/about.html`


------
https://chatgpt.com/codex/tasks/task_e_689729d1d42c832ba6a803d51cf175ec