### PR TITLE
Add responsive mobile burger menu

### DIFF
--- a/header.html
+++ b/header.html
@@ -29,9 +29,26 @@
       <a href="blog.html" class="hover:text-[var(--primary)]">Blog</a>
     </nav>
 
-    <div class="flex items-center space-x-4">
+    <div class="hidden md:flex items-center space-x-4">
       <a href="login.html" class="text-sm hover:text-[var(--primary)]">Log In</a>
       <a href="signup.html" class="px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:bg-orange-700 transition-colors">Sign Up</a>
     </div>
+
+    <button id="burger-btn" class="md:hidden focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+  </div>
+
+  <div id="burger-menu" class="md:hidden fixed top-0 right-0 w-64 h-full bg-white shadow-md transform translate-x-full transition-transform hidden">
+    <nav class="flex flex-col p-6 space-y-4">
+      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Browse</a>
+      <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>
+      <a href="contracts.html" class="hover:text-[var(--primary)]">Contracts</a>
+      <a href="blog.html" class="hover:text-[var(--primary)]">Blog</a>
+      <a href="login.html" class="hover:text-[var(--primary)]">Log In</a>
+      <a href="signup.html" class="hover:text-[var(--primary)]">Sign Up</a>
+    </nav>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- add hamburger button to header for mobile viewports
- include off-canvas mobile navigation menu

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab719d159c832ba4eb75348c915ef7