### PR TITLE
Add sample blog posts with hammer likes

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -16,21 +16,17 @@
   <main class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 id="title" class="text-2xl font-bold mb-2"></h2>
     <p id="content" class="mb-4"></p>
-    <button id="hammer-btn" class="bg-orange-500 text-white px-3 py-1 rounded mb-4">Hammer (<span id="hammer-count">0</span>)</button>
+    <button id="hammer-btn" class="bg-orange-500 text-white px-3 py-1 rounded mb-4">🔨 (<span id="hammer-count">0</span>)</button>
     <div id="comments" class="space-y-2"></div>
-    <form id="comment-form" class="space-y-2 mt-4 hidden">
+    <form id="comment-form" class="space-y-2 mt-4">
       <textarea id="comment-text" required class="w-full p-2 border rounded" placeholder="Add a comment"></textarea>
       <button type="submit" class="bg-orange-500 text-white px-3 py-1 rounded">Comment</button>
     </form>
   </main>
 
-  <script src="firebase-config.js"></script>
   <script type="module">
-    import { initFirebase } from './firebase-init.js';
-    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
-    import { getPost, getComments, addComment, toggleHammer } from './blog.js';
+    import { getPost, getComments, addComment, toggleHammer, toggleCommentHammer } from './blog.js';
 
-    const { auth } = initFirebase();
     const params = new URLSearchParams(window.location.search);
     const postId = params.get('id');
 
@@ -40,24 +36,19 @@
     const hammerCount = document.getElementById('hammer-count');
     const commentsEl = document.getElementById('comments');
     const commentForm = document.getElementById('comment-form');
+    const commentText = document.getElementById('comment-text');
 
-    onAuthStateChanged(auth, user => {
-      if (user) {
-        commentForm.classList.remove('hidden');
-        commentForm.addEventListener('submit', async e => {
-          e.preventDefault();
-          await addComment(postId, user.uid, document.getElementById('comment-text').value);
-          commentForm.reset();
-          loadComments();
-        });
-        hammerBtn.addEventListener('click', async () => {
-          await toggleHammer(postId, user.uid);
-          const post = await getPost(postId);
-          hammerCount.textContent = post.hammerCount || 0;
-        });
-      } else {
-        hammerBtn.disabled = true;
-      }
+    hammerBtn.addEventListener('click', async () => {
+      await toggleHammer(postId);
+      const post = await getPost(postId);
+      hammerCount.textContent = post.hammerCount || 0;
+    });
+
+    commentForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      await addComment(postId, 'anon', commentText.value);
+      commentForm.reset();
+      loadComments();
     });
 
     async function loadPost() {
@@ -80,8 +71,18 @@
       }
       for (const c of comments) {
         const div = document.createElement('div');
-        div.className = 'border-b pb-2';
-        div.textContent = c.text;
+        div.className = 'border-b pb-2 flex justify-between items-center';
+        const span = document.createElement('span');
+        span.textContent = c.text;
+        const btn = document.createElement('button');
+        btn.className = 'text-sm text-gray-600';
+        btn.textContent = `🔨 ${c.hammerCount || 0}`;
+        btn.addEventListener('click', async () => {
+          await toggleCommentHammer(postId, c.id);
+          loadComments();
+        });
+        div.appendChild(span);
+        div.appendChild(btn);
         commentsEl.appendChild(div);
       }
     }

--- a/blog.html
+++ b/blog.html
@@ -26,28 +26,20 @@
     <div id="posts-list" class="space-y-4"></div>
   </main>
 
-  <script src="firebase-config.js"></script>
   <script type="module">
-    import { initFirebase } from './firebase-init.js';
-    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
-    import { createPost, getPosts } from './blog.js';
+    import { createPost, getPosts, getPost, toggleHammer } from './blog.js';
 
-    const { auth } = initFirebase();
     const form = document.getElementById('post-form');
     const list = document.getElementById('posts-list');
     const searchInput = document.getElementById('search');
     let allPosts = [];
 
-    onAuthStateChanged(auth, user => {
-      if (user) {
-        form.classList.remove('hidden');
-        form.addEventListener('submit', async e => {
-          e.preventDefault();
-          await createPost(user.uid, form.title.value, form.content.value);
-          form.reset();
-          loadPosts();
-        });
-      }
+    form.classList.remove('hidden');
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      await createPost('anon', form.title.value, form.content.value);
+      form.reset();
+      loadPosts();
     });
 
     async function loadPosts() {
@@ -87,13 +79,18 @@
         const truncated = post.content.slice(0, 100) + (post.content.length > 100 ? '...' : '');
         preview.textContent = truncated;
 
-        const hammerP = document.createElement('p');
-        hammerP.className = 'text-xs text-gray-500';
-        hammerP.textContent = `Hammers: ${post.hammerCount || 0}`;
+        const hammerBtn = document.createElement('button');
+        hammerBtn.className = 'text-sm text-gray-600';
+        hammerBtn.textContent = `🔨 ${post.hammerCount || 0}`;
+        hammerBtn.addEventListener('click', async () => {
+          await toggleHammer(post.id);
+          const updated = await getPost(post.id);
+          hammerBtn.textContent = `🔨 ${updated.hammerCount || 0}`;
+        });
 
         div.appendChild(h3);
         div.appendChild(preview);
-        div.appendChild(hammerP);
+        div.appendChild(hammerBtn);
         list.appendChild(div);
       }
     }


### PR DESCRIPTION
## Summary
- seed blog with local demo posts stored in browser
- show hammer like buttons on blog posts and comments
- enable commenting and hammering without Firebase

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdaeda12ec832ba245e4865fea2c7d