### PR TITLE
fix: ensure burger menu has background on mobile

### DIFF
--- a/header.html
+++ b/header.html
@@ -14,6 +14,10 @@
       background-color: var(--neutral-bg);
       padding-top: 4rem; /* prevent content being hidden behind header */
     }
+    /* Ensure burger menu is visible on mobile */
+    #burger-menu {
+      background-color: #ffffff;
+    }
   </style>
 
   <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">


### PR DESCRIPTION
## Summary
- add CSS rule to give mobile burger menu a white background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdafd7e284832b9050718c8bf54414