### PR TITLE
fix: ensure burger menu has white background

### DIFF
--- a/header.html
+++ b/header.html
@@ -45,7 +45,7 @@
     </button>
   </div>
 
-  <div id="burger-menu" class="md:hidden fixed top-0 right-0 w-64 h-full bg-white shadow-md transform translate-x-full transition-transform hidden">
+  <div id="burger-menu" class="md:hidden fixed top-0 right-0 w-64 h-full bg-white shadow-md transform translate-x-full transition-transform hidden" style="background-color: #ffffff">
     <nav class="flex flex-col p-6 space-y-4">
       <a href="browse-pros.html" class="hover:text-[var(--primary)]">Browse</a>
       <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>


### PR DESCRIPTION
## Summary
- force burger menu to render with a white background so navigation items remain visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb12fdf98832ba4cdaf5778a97e1d