### PR TITLE
Enforce login for blog posts and limit hammer votes

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -15,6 +15,7 @@
 
   <main class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 id="title" class="text-2xl font-bold mb-2"></h2>
+    <p id="meta" class="text-sm text-gray-500 mb-2"></p>
     <p id="content" class="mb-4"></p>
     <button id="hammer-btn" class="bg-orange-500 text-white px-3 py-1 rounded mb-4">🔨 (<span id="hammer-count">0</span>)</button>
     <div id="comments" class="space-y-2"></div>
@@ -26,11 +27,13 @@
 
   <script type="module">
     import { getPost, getComments, addComment, toggleHammer, toggleCommentHammer } from './blog.js';
+    import { initSupabase } from './supabase-init.js';
 
     const params = new URLSearchParams(window.location.search);
     const postId = params.get('id');
 
     const titleEl = document.getElementById('title');
+    const metaEl = document.getElementById('meta');
     const contentEl = document.getElementById('content');
     const hammerBtn = document.getElementById('hammer-btn');
     const hammerCount = document.getElementById('hammer-count');
@@ -38,15 +41,45 @@
     const commentForm = document.getElementById('comment-form');
     const commentText = document.getElementById('comment-text');
 
+    const supabase = initSupabase();
+    let currentUser = null;
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user) {
+      const { data, error } = await supabase
+        .from('users')
+        .select('account_type')
+        .eq('id', session.user.id)
+        .single();
+      if (!error) {
+        currentUser = { id: session.user.id, email: session.user.email, accountType: data.account_type };
+      }
+    }
+
+    const ACCOUNT_SYMBOLS = { professional: '🛠️', personal: '👤' };
+
+    function getGuestId() {
+      let id = localStorage.getItem('guest-id');
+      if (!id) {
+        id = 'guest-' + Date.now();
+        localStorage.setItem('guest-id', id);
+      }
+      return id;
+    }
+
+    const hammerUserId = currentUser ? currentUser.id : getGuestId();
+
     hammerBtn.addEventListener('click', async () => {
-      await toggleHammer(postId);
-      const post = await getPost(postId);
-      hammerCount.textContent = post.hammerCount || 0;
+      const changed = await toggleHammer(postId, hammerUserId);
+      if (changed) {
+        const post = await getPost(postId);
+        hammerCount.textContent = post.hammerCount || 0;
+        hammerBtn.disabled = true;
+      }
     });
 
     commentForm.addEventListener('submit', async e => {
       e.preventDefault();
-      await addComment(postId, 'anon', commentText.value);
+      await addComment(postId, currentUser ? currentUser.id : 'anon', commentText.value);
       commentForm.reset();
       loadComments();
     });
@@ -60,6 +93,11 @@
       titleEl.textContent = post.title;
       contentEl.textContent = post.content;
       hammerCount.textContent = post.hammerCount || 0;
+      const symbol = ACCOUNT_SYMBOLS[post.accountType] || '';
+      metaEl.textContent = `${symbol} ${post.author}`;
+      if (post.hammeredBy?.includes(hammerUserId)) {
+        hammerBtn.disabled = true;
+      }
     }
 
     async function loadComments() {
@@ -77,9 +115,14 @@
         const btn = document.createElement('button');
         btn.className = 'text-sm text-gray-600';
         btn.textContent = `🔨 ${c.hammerCount || 0}`;
+        if (c.hammeredBy?.includes(hammerUserId)) {
+          btn.disabled = true;
+        }
         btn.addEventListener('click', async () => {
-          await toggleCommentHammer(postId, c.id);
-          loadComments();
+          const changed = await toggleCommentHammer(postId, c.id, hammerUserId);
+          if (changed) {
+            loadComments();
+          }
         });
         div.appendChild(span);
         div.appendChild(btn);

--- a/blog.html
+++ b/blog.html
@@ -28,16 +28,43 @@
 
   <script type="module">
     import { createPost, getPosts, getPost, toggleHammer } from './blog.js';
+    import { initSupabase } from './supabase-init.js';
 
     const form = document.getElementById('post-form');
     const list = document.getElementById('posts-list');
     const searchInput = document.getElementById('search');
     let allPosts = [];
+    let currentUser = null;
 
-    form.classList.remove('hidden');
+    const supabase = initSupabase();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user) {
+      const { data, error } = await supabase
+        .from('users')
+        .select('account_type')
+        .eq('id', session.user.id)
+        .single();
+      if (!error) {
+        currentUser = { id: session.user.id, email: session.user.email, accountType: data.account_type };
+        form.classList.remove('hidden');
+      }
+    }
+
+    const ACCOUNT_SYMBOLS = { professional: '🛠️', personal: '👤' };
+
+    function getGuestId() {
+      let id = localStorage.getItem('guest-id');
+      if (!id) {
+        id = 'guest-' + Date.now();
+        localStorage.setItem('guest-id', id);
+      }
+      return id;
+    }
+
     form.addEventListener('submit', async e => {
       e.preventDefault();
-      await createPost('anon', form.title.value, form.content.value);
+      if (!currentUser) return;
+      await createPost(currentUser, form.title.value, form.content.value);
       form.reset();
       loadPosts();
     });
@@ -62,6 +89,7 @@
         list.innerHTML = '<p class="text-center">No posts found.</p>';
         return;
       }
+      const hammerUserId = currentUser ? currentUser.id : getGuestId();
       for (const post of filtered) {
         const div = document.createElement('div');
         div.className = 'flex bg-white p-4 rounded shadow';
@@ -75,10 +103,18 @@
         const count = document.createElement('span');
         count.className = 'text-sm';
         count.textContent = post.hammerCount || 0;
+        if (post.hammeredBy?.includes(hammerUserId)) {
+          upBtn.disabled = true;
+          upBtn.classList.add('text-orange-500');
+        }
         upBtn.addEventListener('click', async () => {
-          await toggleHammer(post.id);
-          const updated = await getPost(post.id);
-          count.textContent = updated.hammerCount || 0;
+          const changed = await toggleHammer(post.id, hammerUserId);
+          if (changed) {
+            const updated = await getPost(post.id);
+            count.textContent = updated.hammerCount || 0;
+            upBtn.disabled = true;
+            upBtn.classList.add('text-orange-500');
+          }
         });
 
         vote.appendChild(upBtn);
@@ -102,7 +138,8 @@
 
         const meta = document.createElement('div');
         meta.className = 'text-xs text-gray-500 mt-2';
-        meta.textContent = `${post.comments.length} comments`;
+        const symbol = ACCOUNT_SYMBOLS[post.accountType] || '';
+        meta.textContent = `${symbol} ${post.author} · ${post.comments.length} comments`;
 
         content.appendChild(h3);
         content.appendChild(preview);

--- a/blog.js
+++ b/blog.js
@@ -7,8 +7,11 @@ const defaultData = {
       title: 'Welcome to the TradeStone Blog',
       content: 'This is a demo post about using hammers.',
       hammerCount: 0,
+      hammeredBy: [],
+      author: 'Demo Pro',
+      accountType: 'professional',
       comments: [
-        { id: 'c1', text: 'Nice post!', hammerCount: 0 }
+        { id: 'c1', text: 'Nice post!', hammerCount: 0, hammeredBy: [] }
       ]
     },
     {
@@ -16,6 +19,9 @@ const defaultData = {
       title: 'Second Post',
       content: 'Another sample post to show the blog working.',
       hammerCount: 0,
+      hammeredBy: [],
+      author: 'Demo Personal',
+      accountType: 'personal',
       comments: []
     }
   ]
@@ -38,10 +44,19 @@ function saveData(data) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
 
-export async function createPost(userId, title, content) {
+export async function createPost(user, title, content) {
   const data = loadData();
   const id = Date.now().toString();
-  data.posts.unshift({ id, title, content, hammerCount: 0, comments: [] });
+  data.posts.unshift({
+    id,
+    title,
+    content,
+    hammerCount: 0,
+    hammeredBy: [],
+    comments: [],
+    author: user.email,
+    accountType: user.accountType,
+  });
   saveData(data);
   return id;
 }
@@ -60,7 +75,7 @@ export async function addComment(postId, userId, text) {
   const data = loadData();
   const post = data.posts.find(p => p.id === postId);
   if (post) {
-    post.comments.push({ id: Date.now().toString(), text, hammerCount: 0 });
+    post.comments.push({ id: Date.now().toString(), text, hammerCount: 0, hammeredBy: [] });
     saveData(data);
   }
 }
@@ -70,23 +85,35 @@ export async function getComments(postId) {
   return post ? post.comments : [];
 }
 
-export async function toggleHammer(postId) {
+export async function toggleHammer(postId, userId) {
   const data = loadData();
   const post = data.posts.find(p => p.id === postId);
   if (post) {
-    post.hammerCount = (post.hammerCount || 0) + 1;
-    saveData(data);
+    post.hammeredBy = post.hammeredBy || [];
+    if (!post.hammeredBy.includes(userId)) {
+      post.hammeredBy.push(userId);
+      post.hammerCount = (post.hammerCount || 0) + 1;
+      saveData(data);
+      return true;
+    }
   }
+  return false;
 }
 
-export async function toggleCommentHammer(postId, commentId) {
+export async function toggleCommentHammer(postId, commentId, userId) {
   const data = loadData();
   const post = data.posts.find(p => p.id === postId);
   if (post) {
     const comment = post.comments.find(c => c.id === commentId);
     if (comment) {
-      comment.hammerCount = (comment.hammerCount || 0) + 1;
-      saveData(data);
+      comment.hammeredBy = comment.hammeredBy || [];
+      if (!comment.hammeredBy.includes(userId)) {
+        comment.hammeredBy.push(userId);
+        comment.hammerCount = (comment.hammerCount || 0) + 1;
+        saveData(data);
+        return true;
+      }
     }
   }
+  return false;
 }


### PR DESCRIPTION
## Summary
- require Supabase auth to create blog posts
- show author with pro or personal symbols
- prevent multiple hammer votes per user

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb1d53390832bae943bbccad53f7b