### PR TITLE
Ensure burger menu has white background

### DIFF
--- a/loadHeader.js
+++ b/loadHeader.js
@@ -14,6 +14,7 @@ export async function loadHeader() {
     const btn = container.querySelector('#burger-btn');
     const menu = container.querySelector('#burger-menu');
     if (btn && menu) {
+      menu.style.backgroundColor = '#ffffff';
       btn.addEventListener('click', () => {
         menu.classList.toggle('translate-x-full');
         menu.classList.toggle('hidden');


### PR DESCRIPTION
## Summary
- Explicitly set burger menu background to white when loading header

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb3403bc4832bae82013cfe4ef235