### PR TITLE
feat: polish navigation and accessibility

### DIFF
--- a/browse-pros.html
+++ b/browse-pros.html
@@ -106,22 +106,33 @@
       if (profileData.travelRadius && profileData.location) {
         radiusEl.textContent = `Covers ${profileData.travelRadius} miles from ${profileData.location}`;
       }
-      
-      // Create a container for links for better layout control
+
+      if (profileData.tags && profileData.tags.length) {
+        const tags = document.createElement('div');
+        tags.className = 'flex flex-wrap gap-1';
+        profileData.tags.forEach(t => {
+          const span = document.createElement('span');
+          span.textContent = t;
+          span.className = 'text-xs bg-gray-200 rounded px-2 py-1';
+          tags.appendChild(span);
+        });
+        card.appendChild(tags);
+      }
+
       const linksContainer = document.createElement('div');
-      linksContainer.className = 'pt-2 mt-auto'; // 'mt-auto' pushes links to the bottom
+      linksContainer.className = 'pt-2 mt-auto';
 
       const profileLink = document.createElement('a');
       profileLink.href = `professional-profile.html?id=${profileData.id}`;
       profileLink.className = 'text-orange-500 block hover:underline';
       profileLink.textContent = 'View Profile';
 
-      const portfolioLink = document.createElement('a');
-      portfolioLink.href = `portfolio.html?id=${profileData.id}`;
-      portfolioLink.className = 'text-orange-500 block hover:underline';
-      portfolioLink.textContent = 'View Portfolio';
+      const contactBtn = document.createElement('a');
+      contactBtn.href = `messages.html?to=${profileData.id}`;
+      contactBtn.className = 'mt-2 inline-block px-4 py-2 bg-[var(--primary)] text-white rounded text-center font-semibold';
+      contactBtn.textContent = 'Contact';
 
-      linksContainer.append(profileLink, portfolioLink);
+      linksContainer.append(profileLink, contactBtn);
       if (DEMO_MODE) {
         const demoLink = document.createElement('a');
         demoLink.href = '#';
@@ -132,7 +143,7 @@
           const html = `<h2 class="text-lg font-bold mb-2">${profileData.businessName || 'Demo Professional'}</h2><p>Latest review: "Excellent work!"</p><p>Worked previously in ${profileData.location || 'various locations'}.</p>`;
           showDemo(html);
         });
-        linksContainer.appendChild(demoLink);
+      linksContainer.appendChild(demoLink);
       }
       card.append(name, trade, locationEl, ratingEl, radiusEl, linksContainer);
       return card;

--- a/contracts.js
+++ b/contracts.js
@@ -25,6 +25,14 @@ function createCard(contract) {
   const card = document.createElement('div');
   card.className = 'bg-white rounded-lg shadow p-4 flex flex-col space-y-2';
 
+  if (contract.image) {
+    const img = document.createElement('img');
+    img.src = contract.image;
+    img.alt = contract.title;
+    img.className = 'w-full h-32 object-cover mb-2 rounded';
+    card.appendChild(img);
+  }
+
   const title = document.createElement('h2');
   title.className = 'text-lg font-bold';
   title.textContent = contract.title;
@@ -42,6 +50,13 @@ function createCard(contract) {
     card.appendChild(loc);
   }
 
+  if (contract.distance) {
+    const dist = document.createElement('p');
+    dist.className = 'text-sm text-gray-700';
+    dist.textContent = `${contract.distance} miles away`;
+    card.appendChild(dist);
+  }
+
   if (contract.budget) {
     const bud = document.createElement('p');
     bud.className = 'text-sm text-gray-700';
@@ -49,15 +64,27 @@ function createCard(contract) {
     card.appendChild(bud);
   }
 
+  if (contract.tags && contract.tags.length) {
+    const tags = document.createElement('div');
+    tags.className = 'flex flex-wrap gap-1';
+    contract.tags.forEach(t => {
+      const span = document.createElement('span');
+      span.textContent = t;
+      span.className = 'text-xs bg-gray-200 rounded px-2 py-1';
+      tags.appendChild(span);
+    });
+    card.appendChild(tags);
+  }
+
   const view = document.createElement('a');
   view.href = `contract-detail.html?id=${contract.id}`;
-  view.textContent = 'View Details';
+  view.textContent = 'View';
   view.className = 'text-orange-500 hover:underline';
   card.appendChild(view);
 
   const btn = document.createElement('button');
-  btn.textContent = 'Apply';
-  btn.className = 'mt-auto bg-orange-500 text-white px-4 py-1 rounded';
+  btn.textContent = 'Bid';
+  btn.className = 'mt-auto inline-block px-4 py-2 bg-[var(--primary)] text-white rounded font-semibold';
   btn.addEventListener('click', () => applyForContract(contract.id));
   card.appendChild(btn);
 

--- a/footer.html
+++ b/footer.html
@@ -1,10 +1,13 @@
-<footer class="bg-gray-100 border-t mt-10 py-6 text-center">
-  <nav class="mb-4 space-x-4">
+<footer class="fixed bottom-0 left-0 right-0 bg-gray-100 border-t py-4 text-center z-50">
+  <nav class="mb-2 space-x-4">
     <a href="index.html" class="text-gray-700 hover:text-orange-500">Home</a>
-    <a href="about.html" class="text-gray-700 hover:text-orange-500">About</a>
-    <a href="browse-pros.html" class="text-gray-700 hover:text-orange-500">Browse</a>
+    <a href="marketplace.html" class="text-gray-700 hover:text-orange-500">Marketplace</a>
+    <a href="browse-pros.html" class="text-gray-700 hover:text-orange-500">Hire</a>
+    <a href="contracts.html" class="text-gray-700 hover:text-orange-500">Contracts</a>
+    <a href="login.html" class="text-gray-700 hover:text-orange-500">Log in</a>
+    <a href="post.html" class="px-3 py-1 bg-orange-500 text-white rounded">Post a listing</a>
   </nav>
-  <nav class="mb-4 space-x-4 text-sm">
+  <nav class="mb-2 space-x-4 text-sm">
     <a href="terms.html" class="text-gray-500 hover:text-gray-700">Terms of Service</a>
     <a href="privacy.html" class="text-gray-500 hover:text-gray-700">Privacy Policy</a>
   </nav>

--- a/header.html
+++ b/header.html
@@ -13,6 +13,7 @@
       font-family: 'Inter', sans-serif;
       background-color: var(--neutral-bg);
       padding-top: 4rem; /* prevent content being hidden behind header */
+      padding-bottom: 4rem; /* space for sticky footer */
     }
     /* Ensure burger menu is visible on mobile */
     #burger-menu {
@@ -27,15 +28,15 @@
     </a>
 
     <nav class="hidden md:flex items-center space-x-6">
-      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Browse</a>
+      <a href="index.html" class="hover:text-[var(--primary)]">Home</a>
       <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>
+      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Hire</a>
       <a href="contracts.html" class="hover:text-[var(--primary)]">Contracts</a>
-      <a href="blog.html" class="hover:text-[var(--primary)]">Blog</a>
     </nav>
 
     <div class="hidden md:flex items-center space-x-4">
-      <a href="login.html" class="text-sm hover:text-[var(--primary)]">Log In</a>
-      <a href="signup.html" class="px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:bg-orange-700 transition-colors">Sign Up</a>
+      <a href="login.html" class="text-sm hover:text-[var(--primary)]">Log in</a>
+      <a href="post.html" class="px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:bg-orange-700 transition-colors">Post a listing</a>
     </div>
 
     <button id="burger-btn" class="md:hidden focus:outline-none">
@@ -47,12 +48,12 @@
 
   <div id="burger-menu" class="md:hidden fixed top-0 right-0 w-64 h-full bg-white shadow-md transform translate-x-full transition-transform hidden" style="background-color: #ffffff">
     <nav class="flex flex-col p-6 space-y-4">
-      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Browse</a>
+      <a href="index.html" class="hover:text-[var(--primary)]">Home</a>
       <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>
+      <a href="browse-pros.html" class="hover:text-[var(--primary)]">Hire</a>
       <a href="contracts.html" class="hover:text-[var(--primary)]">Contracts</a>
-      <a href="blog.html" class="hover:text-[var(--primary)]">Blog</a>
-      <a href="login.html" class="hover:text-[var(--primary)]">Log In</a>
-      <a href="signup.html" class="hover:text-[var(--primary)]">Sign Up</a>
+      <a href="login.html" class="hover:text-[var(--primary)]">Log in</a>
+      <a href="post.html" class="px-3 py-2 bg-[var(--primary)] text-white rounded">Post a listing</a>
     </nav>
   </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@
       <p class="text-lg mb-8 max-w-xl mx-auto">
         Connect with professionals, buy surplus materials, and win contracts with ease.
       </p>
-      <a href="signup.html"
-         class="px-6 py-3 bg-[var(--primary)] text-white rounded-lg font-semibold hover:bg-orange-700 transition-colors">
-        Get Started
-      </a>
+        <a href="signup.html"
+           class="px-6 py-3 bg-[var(--primary)] text-white rounded-lg font-semibold hover:bg-orange-700 transition-colors">
+          Sign up free
+        </a>
     </div>
   </section>
 

--- a/login.html
+++ b/login.html
@@ -20,7 +20,7 @@
       <a href="professional-login.html" class="btn-secondary">Professional Login</a>
       <a href="personal-login.html" class="btn-secondary">Personal Login</a>
     </div>
-    <p class="text-sm">Need an account? <a href="signup.html" class="text-orange-600 font-medium hover:underline">Sign up</a></p>
+      <p class="text-sm">Need an account? <a href="signup.html" class="text-orange-600 font-medium hover:underline">Sign up free</a></p>
   </main>
 
   <div id="footer"></div>

--- a/marketplace.js
+++ b/marketplace.js
@@ -40,6 +40,31 @@ function createCard(item) {
     card.appendChild(locationEl);
   }
 
+  if (item.distance) {
+    const dist = document.createElement('p');
+    dist.className = 'text-sm text-gray-700';
+    dist.textContent = `${item.distance} miles away`;
+    card.appendChild(dist);
+  }
+
+  if (item.tags && item.tags.length) {
+    const tags = document.createElement('div');
+    tags.className = 'flex flex-wrap gap-1';
+    item.tags.forEach(t => {
+      const span = document.createElement('span');
+      span.textContent = t;
+      span.className = 'text-xs bg-gray-200 rounded px-2 py-1';
+      tags.appendChild(span);
+    });
+    card.appendChild(tags);
+  }
+
+  const viewBtn = document.createElement('a');
+  viewBtn.href = `#`;
+  viewBtn.className = 'mt-auto inline-block px-4 py-2 bg-[var(--primary)] text-white rounded text-center font-semibold';
+  viewBtn.textContent = 'View';
+  card.appendChild(viewBtn);
+
   if (DEMO_MODE) {
     const demoLink = document.createElement('a');
     demoLink.href = '#';

--- a/personal-login.html
+++ b/personal-login.html
@@ -39,8 +39,8 @@
       <p>Password: <code>demopass</code></p>
     </div>
     <p class="mt-4 text-center text-sm">
-      Don’t have an account?
-      <a href="personal-signup.html" class="text-orange-500 font-medium">Sign up</a>
+        Don’t have an account?
+        <a href="personal-signup.html" class="text-orange-500 font-medium">Sign up free</a>
     </p>
   </main>
 

--- a/personal-signup.html
+++ b/personal-signup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Personal Sign Up – TradeStone</title>
+    <title>Sign up free – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="text-gray-900 font-sans pb-16">
@@ -14,7 +14,7 @@
   </script>
 
   <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
-    <h1 class="text-2xl font-bold mb-6 text-center">Create Personal Account</h1>
+      <h1 class="text-2xl font-bold mb-6 text-center">Sign up free</h1>
     <form id="signup-form" class="space-y-4">
       <input type="hidden" name="accountType" value="personal"/>
       <div>
@@ -32,10 +32,10 @@
         <input id="confirmPassword" name="confirmPassword" type="password" required
                class="w-full p-2 border rounded"/>
       </div>
-      <button type="submit"
-              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
-        Sign Up
-      </button>
+        <button type="submit"
+                class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
+          Sign up free
+        </button>
     </form>
     <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
   </main>

--- a/post.html
+++ b/post.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Post Item – TradeStone</title>
+    <title>Post a listing – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="text-gray-900 font-sans pb-16">
@@ -14,7 +14,7 @@
   </script>
 
   <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
-    <h2 class="text-2xl font-bold mb-4 text-center">Post Item</h2>
+      <h2 class="text-2xl font-bold mb-4 text-center">Post a listing</h2>
     <form id="item-form" class="space-y-4" enctype="multipart/form-data">
       <div>
         <label for="title" class="block mb-1">Title</label>
@@ -53,7 +53,7 @@
         <input id="images" name="images" type="file" accept="image/*" multiple class="w-full" />
       </div>
       <div id="error-msg" class="text-red-500 text-center"></div>
-      <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Post Item</button>
+        <button type="submit" class="w-full py-2 bg-orange-500 text-white rounded">Post a listing</button>
     </form>
     <div id="status-msg" class="text-red-500 mt-2 text-center"></div>
   </main>

--- a/professional-login.html
+++ b/professional-login.html
@@ -39,8 +39,8 @@
       <p>Password: <code>demopass</code></p>
     </div>
     <p class="mt-4 text-center text-sm">
-      Don’t have an account?
-      <a href="professional-signup.html" class="text-orange-500 font-medium">Sign up</a>
+        Don’t have an account?
+        <a href="professional-signup.html" class="text-orange-500 font-medium">Join as Pro</a>
     </p>
   </main>
 

--- a/professional-signup.html
+++ b/professional-signup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Professional Sign Up – TradeStone</title>
+    <title>Join as Pro – TradeStone</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="text-gray-900 font-sans pb-16">
@@ -14,7 +14,7 @@
   </script>
 
   <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow">
-    <h1 class="text-2xl font-bold mb-6 text-center">Create Professional Account</h1>
+      <h1 class="text-2xl font-bold mb-6 text-center">Join as Pro</h1>
     <form id="signup-form" class="space-y-4">
       <input type="hidden" name="accountType" value="professional"/>
       <div>
@@ -32,10 +32,10 @@
         <input id="confirmPassword" name="confirmPassword" type="password" required
                class="w-full p-2 border rounded"/>
       </div>
-      <button type="submit"
-              class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
-        Sign Up
-      </button>
+        <button type="submit"
+                class="w-full py-2 bg-orange-500 text-white rounded-lg font-medium">
+          Join as Pro
+        </button>
     </form>
     <div id="error-msg" class="text-red-500 mt-2 text-center"></div>
   </main>

--- a/signup.html
+++ b/signup.html
@@ -16,10 +16,10 @@
 
   <main class="max-w-md mx-auto p-4 bg-white rounded-xl shadow text-center space-y-6">
     <h1 class="text-2xl font-bold">Sign Up</h1>
-    <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="professional-signup.html" class="btn-primary">Professional Sign Up</a>
-      <a href="personal-signup.html" class="btn-primary">Personal Sign Up</a>
-    </div>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="professional-signup.html" class="btn-primary">Join as Pro</a>
+        <a href="personal-signup.html" class="btn-primary">Sign up free</a>
+      </div>
     <p class="text-sm">Already have an account? <a href="login.html" class="text-orange-600 font-medium hover:underline">Log in</a></p>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -47,3 +47,14 @@ body {
   box-shadow: 0 4px 6px rgba(0,0,0,0.1);
   transform: translateY(-2px);
 }
+
+/* Accessible focus states */
+a:focus, button:focus, input:focus, select:focus, textarea:focus {
+  outline: 2px solid #ea580c;
+  outline-offset: 2px;
+}
+
+/* Larger touch targets */
+button, input, select, textarea {
+  min-height: 44px;
+}


### PR DESCRIPTION
## Summary
- Add sticky header and footer with global navigation and consistent orange call-to-action buttons
- Revise microcopy for onboarding flows and marketplace listings
- Improve card layouts and form accessibility with focus outlines and larger tap targets

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb669cb04832b9f705f7bf22ff68e