### PR TITLE
Enhance contract detail metadata and question privacy

### DIFF
--- a/contract-detail.html
+++ b/contract-detail.html
@@ -15,9 +15,12 @@
 
   <main id="contract-content" class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
     <h2 id="contract-title" class="text-2xl font-bold mb-2"></h2>
-    <p id="contract-description" class="mb-4"></p>
+    <p id="contract-scope" class="mb-4"></p>
     <p id="contract-budget" class="text-gray-700"></p>
-    <p id="contract-location" class="text-gray-700 mb-4"></p>
+    <p id="contract-location" class="text-gray-700"></p>
+    <p id="contract-due-date" class="text-gray-700"></p>
+    <p id="contract-issuer" class="text-gray-700"></p>
+    <p id="contract-approval" class="text-gray-700 mb-4"></p>
 
     <div id="contract-documents" class="mb-6"></div>
     <div id="contract-questions" class="mb-6"></div>


### PR DESCRIPTION
## Summary
- Show scope, due date, issuer and approval status on contract pages
- Load issuer name from profile data and hide private questions from unrelated users

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdbee599d0832ba81cf062d85244e5