### PR TITLE
feat: enhance bid flow and add admin tools

### DIFF
--- a/admin-approval.html
+++ b/admin-approval.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Approval – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-2xl mx-auto p-4 bg-white rounded-xl shadow">
+    <h2 class="text-2xl font-bold mb-4">Pending Listings</h2>
+    <div id="pending-listings"></div>
+  </main>
+
+  <script type="module" src="./admin-approval.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module">
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html').then(res => res.text()).then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>

--- a/admin-approval.js
+++ b/admin-approval.js
@@ -1,0 +1,50 @@
+import { initFirebase } from './firebase-init.js';
+import {
+  collection,
+  getDocs,
+  updateDoc,
+  doc
+} from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+
+const { db, auth } = initFirebase();
+const listEl = document.getElementById('pending-listings');
+
+onAuthStateChanged(auth, user => {
+  if (user) {
+    loadListings();
+  }
+});
+
+async function loadListings() {
+  listEl.innerHTML = '';
+  const snap = await getDocs(collection(db, 'contracts'));
+  snap.forEach(d => {
+    const data = d.data();
+    if (data.status === 'pending') {
+      const div = document.createElement('div');
+      div.className = 'border p-2 mb-4';
+      const title = document.createElement('h3');
+      title.className = 'font-semibold';
+      title.textContent = data.title || 'Untitled';
+      const suggestion = document.createElement('p');
+      suggestion.className = 'text-sm text-gray-600 mb-2';
+      suggestion.textContent = suggestImprovement(data.description || '');
+      const approve = document.createElement('button');
+      approve.className = 'bg-green-500 text-white px-2 py-1 rounded mr-2';
+      approve.textContent = 'Approve';
+      approve.onclick = () => updateDoc(doc(db, 'contracts', d.id), { status: 'approved' });
+      const reject = document.createElement('button');
+      reject.className = 'bg-red-500 text-white px-2 py-1 rounded';
+      reject.textContent = 'Reject';
+      reject.onclick = () => updateDoc(doc(db, 'contracts', d.id), { status: 'rejected' });
+      div.append(title, suggestion, approve, reject);
+      listEl.appendChild(div);
+    }
+  });
+}
+
+function suggestImprovement(description) {
+  if (!description) return 'Add a detailed description to attract better bids.';
+  return description.length < 50 ? 'Consider providing more details.' : 'Looks good!';
+}

--- a/contract-detail.html
+++ b/contract-detail.html
@@ -25,6 +25,10 @@
     <form id="bid-form" class="space-y-2 hidden">
       <input id="bid-amount" type="number" step="0.01" min="0" required class="w-full p-2 border rounded" placeholder="Bid Amount (£)">
       <textarea id="bid-message" class="w-full p-2 border rounded" placeholder="Message"></textarea>
+      <textarea id="bid-milestones" class="w-full p-2 border rounded" placeholder="Milestones (one per line)"></textarea>
+      <input id="bid-timeline" type="date" class="w-full p-2 border rounded" />
+      <input id="bid-portfolio" type="url" class="w-full p-2 border rounded" placeholder="Portfolio URL">
+      <input id="bid-files" type="file" multiple class="w-full" />
       <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded">Submit Bid</button>
     </form>
     <button id="watch-btn" class="mt-4 bg-orange-500 text-white px-4 py-2 rounded hidden">Add to Watchlist</button>

--- a/contract-detail.js
+++ b/contract-detail.js
@@ -9,8 +9,9 @@ import {
   serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+import { ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
 
-const { db, auth } = initFirebase();
+const { db, auth, storage } = initFirebase();
 const params = new URLSearchParams(window.location.search);
 const contractId = params.get('id');
 
@@ -96,10 +97,33 @@ async function loadQuestions() {
 async function submitBid(e) {
   e.preventDefault();
   if (!currentUser || !isPro) return;
+  const filesInput = document.getElementById('bid-files');
+  const milestonesText = document.getElementById('bid-milestones').value;
+  const timeline = document.getElementById('bid-timeline').value;
+  const portfolio = document.getElementById('bid-portfolio').value.trim();
+
+  const milestones = milestonesText
+    .split('\n')
+    .map(m => m.trim())
+    .filter(Boolean);
+
+  const uploadedFiles = [];
+  if (filesInput && filesInput.files) {
+    for (const f of filesInput.files) {
+      const r = ref(storage, `bids/${contractId}/${currentUser.uid}/${f.name}`);
+      await uploadBytes(r, f);
+      uploadedFiles.push(await getDownloadURL(r));
+    }
+  }
+
   await addDoc(collection(db, 'contracts', contractId, 'bids'), {
     bidder: currentUser.uid,
     amount: parseFloat(document.getElementById('bid-amount').value) || 0,
     message: document.getElementById('bid-message').value.trim(),
+    milestones,
+    timeline,
+    portfolio,
+    files: uploadedFiles,
     createdAt: serverTimestamp()
   });
   bidForm.reset();

--- a/po-upload.html
+++ b/po-upload.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Purchase Order Upload – TradeStone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="text-gray-900 font-sans pb-16">
+  <div id="header"></div>
+  <script type="module">
+    import { loadHeader } from './loadHeader.js';
+    loadHeader();
+  </script>
+
+  <main class="max-w-xl mx-auto p-4 bg-white rounded-xl shadow">
+    <h2 class="text-2xl font-bold mb-4">Upload Purchase Order</h2>
+    <form id="po-form" class="space-y-2">
+      <input id="po-file" type="file" required class="w-full" />
+      <textarea id="po-status" class="w-full p-2 border rounded" placeholder="Status update"></textarea>
+      <button type="submit" class="bg-orange-500 text-white px-4 py-2 rounded">Upload</button>
+    </form>
+    <ul id="status-timeline" class="mt-4 space-y-2"></ul>
+  </main>
+
+  <script type="module" src="./po-upload.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module">
+    import { initFirebase } from './firebase-init.js';
+    initFirebase();
+  </script>
+  <div id="footer"></div>
+  <script>
+    fetch('footer.html').then(res => res.text()).then(html => { document.getElementById('footer').innerHTML = html; });
+  </script>
+</body>
+</html>

--- a/po-upload.js
+++ b/po-upload.js
@@ -1,0 +1,53 @@
+import { initFirebase } from './firebase-init.js';
+import {
+  collection,
+  addDoc,
+  getDocs,
+  serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-auth.js';
+import { ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/11.7.3/firebase-storage.js';
+
+const { db, auth, storage } = initFirebase();
+const params = new URLSearchParams(window.location.search);
+const contractId = params.get('id');
+
+const form = document.getElementById('po-form');
+const timelineEl = document.getElementById('status-timeline');
+
+onAuthStateChanged(auth, user => {
+  if (user) {
+    form.addEventListener('submit', e => submitPO(e, user.uid));
+    loadTimeline();
+  }
+});
+
+async function submitPO(e, uid) {
+  e.preventDefault();
+  const file = document.getElementById('po-file').files[0];
+  const status = document.getElementById('po-status').value.trim();
+  if (!file) return;
+  const r = ref(storage, `purchaseOrders/${contractId}/${uid}/${file.name}`);
+  await uploadBytes(r, file);
+  const url = await getDownloadURL(r);
+  await addDoc(collection(db, 'contracts', contractId, 'purchaseOrders'), {
+    user: uid,
+    url,
+    status,
+    createdAt: serverTimestamp()
+  });
+  form.reset();
+  await loadTimeline();
+}
+
+async function loadTimeline() {
+  timelineEl.innerHTML = '';
+  const snap = await getDocs(collection(db, 'contracts', contractId, 'purchaseOrders'));
+  snap.forEach(d => {
+    const data = d.data();
+    const li = document.createElement('li');
+    const created = data.createdAt?.toDate ? data.createdAt.toDate() : new Date();
+    li.textContent = `${data.status || 'Uploaded'} - ${created.toLocaleString()}`;
+    timelineEl.appendChild(li);
+  });
+}


### PR DESCRIPTION
## Summary
- allow professionals to submit richer bids with milestones, timeline, portfolio links and attachments
- support purchase-order uploads and status timeline
- add admin approval page with basic listing suggestions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf07a470832bb5dd08c4a463b6d3