### PR TITLE
fix: set burger menu background

### DIFF
--- a/header.html
+++ b/header.html
@@ -15,9 +15,9 @@
       padding-top: 4rem; /* prevent content being hidden behind header */
       padding-bottom: 4rem; /* space for sticky footer */
     }
-    /* Ensure burger menu is visible on mobile */
+    /* Ensure burger menu uses solid background */
     #burger-menu {
-      background-color: #ffffff;
+      background-color: var(--neutral-bg);
     }
   </style>
 
@@ -46,7 +46,7 @@
     </button>
   </div>
 
-  <div id="burger-menu" class="md:hidden fixed top-0 right-0 w-64 h-full bg-white shadow-md transform translate-x-full transition-transform hidden" style="background-color: #ffffff">
+  <div id="burger-menu" class="md:hidden fixed top-0 right-0 w-64 h-full shadow-md transform translate-x-full transition-transform hidden">
     <nav class="flex flex-col p-6 space-y-4">
       <a href="index.html" class="hover:text-[var(--primary)]">Home</a>
       <a href="marketplace.html" class="hover:text-[var(--primary)]">Marketplace</a>

--- a/loadHeader.js
+++ b/loadHeader.js
@@ -14,7 +14,7 @@ export async function loadHeader() {
     const btn = container.querySelector('#burger-btn');
     const menu = container.querySelector('#burger-menu');
     if (btn && menu) {
-      menu.style.backgroundColor = '#ffffff';
+      menu.style.backgroundColor = 'var(--neutral-bg)';
       btn.addEventListener('click', () => {
         menu.classList.toggle('translate-x-full');
         menu.classList.toggle('hidden');


### PR DESCRIPTION
## Summary
- ensure burger menu uses solid neutral background instead of being transparent
- apply matching color via JS when loading header

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c087b07cb0832bb2ce0c4c549f2cce