### PR TITLE
Add Supabase listings query example and ignore env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 firebase-config.js
+.env

--- a/index.html
+++ b/index.html
@@ -87,5 +87,15 @@
       .then(html => { document.getElementById('footer').innerHTML = html; })
       .catch(err => console.error('Failed to load footer', err));
   </script>
+  <script type="module">
+    import { supabase } from './js/supabaseClient.js';
+
+    // example: read rows
+    const { data, error } = await supabase
+      .from('listings')
+      .select('*')
+      .limit(10);
+    console.log(data, error);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ignore `.env` files to keep local secrets out of version control
- Demonstrate Supabase usage on the homepage by querying the first ten `listings`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7090ac51c832b8f512bd871019eff