### PR TITLE
fix: load supabase client in browser

### DIFF
--- a/supabase-init.js
+++ b/supabase-init.js
@@ -1,4 +1,16 @@
-import { createClient } from '@supabase/supabase-js';
+// Dynamic import of the Supabase client so that the app works both in
+// Node.js (for scripts or tests) and directly in the browser without a
+// bundler.  The previous implementation relied on a bare import
+// (`@supabase/supabase-js`) which browsers cannot resolve on their own,
+// causing login pages that use this helper to fail to load.
+let createClient;
+if (typeof window === 'undefined') {
+  // Node/SSR environment – use the installed package.
+  ({ createClient } = await import('@supabase/supabase-js'));
+} else {
+  // Browser environment – load the ESM build from a CDN.
+  ({ createClient } = await import('https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm'));
+}
 
 const supabaseUrl = 'https://ifjapjnxgkgtyjqlrriu.supabase.co';
 


### PR DESCRIPTION
## Summary
- dynamically import Supabase client, using CDN in browser and local package in Node
- enables login pages to load Supabase without bundler

## Testing
- `node -e "import('./supabase-init.js').then(m=>console.log('exports', Object.keys(m)))"`
- `SUPABASE_KEY=... node -e "import('./supabase-init.js').then(m=>{const sb=m.initSupabase(); console.log('client exists', typeof sb === 'object');})"`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c70e6f6304832bac29be8978ec0222